### PR TITLE
Multipart support for linear systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 *.lo
 *.btr
+*.csv
 .deps
 .dirstamp
 *.~HEAD~*

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,9 +3,10 @@ hypredrive_SOURCES = src/main.c
 hypredrive_LDADD = libHYPREDRV.la
 
 lib_LTLIBRARIES = libHYPREDRV.la
-libHYPREDRV_la_SOURCES = src/error.c src/info.c src/stats.c src/utils.c src/containers.c src/yaml.c src/field.c\
-                         src/linsys.c src/cheby.c src/amg.c src/fsai.c src/ilu.c src/mgr.c src/precon.c src/pcg.c\
-                         src/gmres.c src/fgmres.c src/bicgstab.c src/solver.c src/args.c src/HYPREDRV.c
+libHYPREDRV_la_SOURCES = src/error.c src/info.c src/stats.c src/utils.c src/containers.c src/yaml.c\
+                         src/field.c src/vector.c src/matrix.c src/linsys.c src/cheby.c src/amg.c\
+                         src/fsai.c src/ilu.c src/mgr.c src/precon.c src/pcg.c src/gmres.c src/fgmres.c\
+                         src/bicgstab.c src/solver.c src/args.c src/HYPREDRV.c
 libHYPREDRV_la_CFLAGS = $(AM_CPPFLAGS) -fvisibility=hidden
 libHYPREDRV_la_LDFLAGS = -version-info 0:1:0
 

--- a/configure.ac
+++ b/configure.ac
@@ -182,6 +182,10 @@ dnl Check for libHYPRE
 AC_CHECK_LIB([HYPRE], [HYPRE_IJMatrixCreate], [],
              [AC_MSG_ERROR([HYPRE library not found or not usable])])
 
+dnl Check for HYPRE headers
+AC_CHECK_HEADER([HYPRE_config.h], [],
+                [AC_MSG_ERROR([HYPRE headers not found or not usable. Please ensure the correct path is specified with --with-hypre-include and the headers are installed.])])
+
 dnl Check for minimum HYPRE version
 AC_LANG_PUSH([C])
 AC_MSG_CHECKING([for HYPRE version])
@@ -192,10 +196,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <HYPRE_config.h>],
                   [AC_MSG_RESULT([sufficient])],
                   [AC_MSG_ERROR([HYPRE library version is too old. Use hypre >= 2.31.0])])
 AC_LANG_POP([C])
-
-dnl Check for HYPRE headers
-AC_CHECK_HEADER([HYPRE_config.h], [],
-                [AC_MSG_ERROR([HYPRE headers not found or not usable. Please ensure the correct path is specified with --with-hypre-include and the headers are installed.])])
 
 AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_HEADERS([HYPREDRV_config.h])

--- a/docs/usrman-src/input_file_structure.rst
+++ b/docs/usrman-src/input_file_structure.rst
@@ -43,6 +43,23 @@ The ``general`` section contains global settings that apply to the entire execut
   repeated. Useful for benchmarking and profiling. The default value for this parameter is
   `1`.
 
+- ``dev_pool_size`` - Initial size of the umpire's device memory pool. This parameter is
+  neglected when hypre is *not* configured with umpire support. The default value for this
+  parameter is `8 GB`.
+
+- ``uvm_pool_size`` - Initial size of the umpire's unified virtual memory pool. This
+  parameter is neglected when hypre is *not* configured with umpire support. The default
+  value for this parameter is `8 GB`.
+
+- ``host_pool_size`` - Initial size of the umpire's host memory pool. This parameter is
+  neglected when hypre is *not* configured with umpire support. The default value for this
+  parameter is `8 GB`.
+
+- ``pinned_pool_size`` - Initial size of the umpire's host memory pool. This parameter is
+  neglected when hypre is *not* configured with umpire support. The default value for this
+  parameter is `512 MB`.
+
+
 An example code block for the ``general`` section is given below:
 
 .. code-block:: yaml
@@ -52,6 +69,10 @@ An example code block for the ``general`` section is given below:
       statistics: yes
       use_millisec: no
       num_repetitions: 1
+      dev_pool_size: 8.0
+      uvm_pool_size: 8.0
+      host_pool_size: 8.0
+      pinned_pool_size: 0.5
 
 Linear System
 -------------

--- a/include/args.h
+++ b/include/args.h
@@ -23,6 +23,10 @@ typedef struct input_args_struct {
    int           warmup;
    int           statistics;
    int           num_repetitions;
+   double        dev_pool_size;
+   double        uvm_pool_size;
+   double        host_pool_size;
+   double        pinned_pool_size;
 
    LS_args       ls;
 

--- a/include/containers.h
+++ b/include/containers.h
@@ -42,7 +42,12 @@ typedef struct IntArray_struct
 {
    int      *data;
    size_t    size;
-   size_t    num_unique_entries;
+
+   int      *unique_data;
+   size_t    unique_size;
+
+   int      *g_unique_data;
+   size_t    g_unique_size;
 } IntArray;
 
 IntArray* IntArrayCreate(size_t);

--- a/include/error.h
+++ b/include/error.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -33,7 +34,8 @@ typedef enum ErrorCode_enum
    ERROR_INVALID_SOLVER         = 0x00001000, // 13th bit
    ERROR_INVALID_PRECON         = 0x00002000, // 14th bit
    ERROR_FILE_NOT_FOUND         = 0x00004000, // 15th bit
-   ERROR_UNKNOWN_HYPREDRV_OBJ   = 0x00008000, // 16th bit
+   ERROR_FILE_UNEXPECTED_ENTRY  = 0x00008000, // 16th bit
+   ERROR_UNKNOWN_HYPREDRV_OBJ   = 0x00010000, // 17th bit
    ERROR_UNKNOWN_TIMING         = 0x20000000, // 29th bit
    ERROR_UNKNOWN                = 0x40000000  // 30th bit
 } ErrorCode;
@@ -49,7 +51,7 @@ bool DistributedErrorCodeActive(MPI_Comm);
 /*******************************************************************************
  *******************************************************************************/
 
-void ErrorMsgAdd(const char*);
+void ErrorMsgAdd(const char*, ...);
 void ErrorMsgAddCodeWithCount(ErrorCode, const char*);
 void ErrorMsgAddMissingKey(const char*);
 void ErrorMsgAddExtraKey(const char*);

--- a/include/linsys.h
+++ b/include/linsys.h
@@ -64,4 +64,7 @@ void LinearSystemComputeResidualNorm(HYPRE_IJMatrix, HYPRE_IJVector, HYPRE_IJVec
 long long int LinearSystemMatrixGetNumRows(HYPRE_IJMatrix);
 long long int LinearSystemMatrixGetNumNonzeros(HYPRE_IJMatrix);
 
+void IJVectorReadMultipartBinary(const char*, MPI_Comm, uint64_t, HYPRE_IJVector*);
+void IJMatrixReadMultipartBinary(const char*, MPI_Comm, uint64_t, HYPRE_IJMatrix*);
+
 #endif /* LINSYS_HEADER */

--- a/include/utils.h
+++ b/include/utils.h
@@ -19,7 +19,8 @@
 
 char* StrToLowerCase(char*);
 char* StrTrim(char*);
-int CheckBinaryDataExists(const char* prefix);
+int CheckBinaryDataExists(const char*);
+int CountNumberOfPartitions(const char*);
 int ComputeNumberOfDigits(int);
 void SplitFilename(const char*, char**, char**);
 void CombineFilename(const char*, const char*, char**);
@@ -27,12 +28,34 @@ void CombineFilename(const char*, const char*, char**);
 /*******************************************************************************
  *******************************************************************************/
 
+/* Helper macros to check if HYPRE_DEVELOP_NUMBER is defined */
+#if defined(HYPRE_DEVELOP_NUMBER)
+  #define HYPRE_DEVELOP_NUMBER_EXISTS 1
+#else
+  #define HYPRE_DEVELOP_NUMBER_EXISTS 0
+#endif
+
+/* Check if HYPRE_DEVELOP_NUMBER is greater than a given value */
+#define HYPRE_DEVELOP_NUMBER_GT(develop) \
+    (HYPRE_DEVELOP_NUMBER > (develop))
+
+/* Check if HYPRE_RELEASE_NUMBER is greater than a given value */
+#define HYPRE_RELEASE_NUMBER_GT(release) \
+    (HYPRE_RELEASE_NUMBER > (release))
+
+/* Check for a specific hypre release number and whether
+   HYPRE_DEVELOP_NUMBER is defined and greater than a given value */
+#define HYPRE_RELEASE_NUMBER_EQ_AND_DEVELOP_NUMBER_GT(release, develop) \
+    (HYPRE_RELEASE_NUMBER == (release) &&\
+     HYPRE_DEVELOP_NUMBER_EXISTS &&\
+     HYPRE_DEVELOP_NUMBER_GT(develop))
+
 /* Check for minimum HYPRE version in order to allow certain features */
 #define HYPRE_CHECK_MIN_VERSION(release, develop) \
-    (HYPRE_RELEASE_NUMBER > (release) || \
-    (HYPRE_RELEASE_NUMBER == (release) && \
-     (defined(HYPRE_DEVELOP_NUMBER) && HYPRE_DEVELOP_NUMBER > (develop))))
+    (HYPRE_RELEASE_NUMBER_GT(release) ||\
+     HYPRE_RELEASE_NUMBER_EQ_AND_DEVELOP_NUMBER_GT(release, develop))
 
+#define GB_TO_BYTES (1 << 30)
 #define MAX_DIVISOR_LENGTH 84
 #define PRINT_DASHED_LINE(_l) for (size_t i = 0; i < (_l); i++) { printf("-"); } printf("\n");
 #define PRINT_EQUAL_LINE(_l)  for (size_t i = 0; i < (_l); i++) { printf("="); } printf("\n");

--- a/include/yaml.h
+++ b/include/yaml.h
@@ -99,7 +99,7 @@ char* YAMLnodeFindChildValueByKey(YAMLnode*, const char*);
          { \
             _node->mapped_val = (char*) malloc(_length * sizeof(char)); \
          } \
-         else if (_length > strlen(_node->mapped_val)) \
+         else if (_length > (int) strlen(_node->mapped_val)) \
          { \
             _node->mapped_val = (char*) realloc(_node->mapped_val, _length * sizeof(char)); \
          } \

--- a/src/HYPREDRV.c
+++ b/src/HYPREDRV.c
@@ -189,7 +189,23 @@ HYPREDRV_SetGlobalOptions(HYPREDRV_t obj)
       {
          HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
          HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
-         HYPRE_SetSpGemmUseVendor(0);
+         HYPRE_SetSpGemmUseVendor(0); // TODO: Control this via input option
+         HYPRE_SetSpMVUseVendor(0);   // TODO: Control this via input option
+
+#if defined(HYPRE_USING_UMPIRE)
+        /* Setup Umpire pools */
+        HYPRE_SetUmpireDevicePoolName("DEVICE_POOL");
+        HYPRE_SetUmpireDevicePoolSize(obj->iargs->dev_pool_size);
+
+        HYPRE_SetUmpireUMPoolName("UM_POOL");
+        HYPRE_SetUmpireUMPoolSize(obj->iargs->uvm_pool_size);
+
+        HYPRE_SetUmpireHostPoolName("HOST_POOL");
+        HYPRE_SetUmpireHostPoolSize(obj->iargs->host_pool_size);
+
+        HYPRE_SetUmpirePinnedPoolName("PINNED_POOL");
+        HYPRE_SetUmpirePinnedPoolSize(obj->iargs->pinned_pool_size);
+#endif
       }
       else
       {
@@ -261,6 +277,7 @@ HYPREDRV_LinearSystemBuild(HYPREDRV_t obj)
          printf("Solving linear system #%d ", StatsGetLinearSystemID());
          printf("with %lld rows and %lld nonzeros...\n", num_rows, num_nonzeros);
       }
+      HYPRE_ClearAllErrors();
    }
    else
    {
@@ -454,6 +471,7 @@ HYPREDRV_LinearSolverSetup(HYPREDRV_t obj)
          SolverSetup(obj->iargs->precon_method, obj->iargs->solver_method,
                      obj->precon, obj->solver, obj->mat_M, obj->vec_b, obj->vec_x);
       }
+      HYPRE_ClearAllErrors();
    }
    else
    {

--- a/src/args.c
+++ b/src/args.c
@@ -20,9 +20,13 @@ InputArgsCreate(input_args **iargs_ptr)
    input_args *iargs = (input_args*) malloc(sizeof(input_args));
 
    /* Set general default options */
-   iargs->warmup = 0;
-   iargs->num_repetitions = 1;
-   iargs->statistics = 1;
+   iargs->warmup           = 0;
+   iargs->num_repetitions  = 1;
+   iargs->statistics       = 1;
+   iargs->dev_pool_size    = 8.0 * GB_TO_BYTES;
+   iargs->uvm_pool_size    = 8.0 * GB_TO_BYTES;
+   iargs->host_pool_size   = 8.0 * GB_TO_BYTES;
+   iargs->pinned_pool_size = 0.5 * GB_TO_BYTES;
 
    /* Set default Linear System options */
    LinearSystemSetDefaultArgs(&iargs->ls);
@@ -126,7 +130,23 @@ InputArgsParseGeneral(input_args *iargs, YAMLtree *tree)
       }
       else if (!strcmp(child->key, "num_repetitions"))
       {
-         iargs->num_repetitions = (HYPRE_Int) atoi(child->val);
+         iargs->num_repetitions = atoi(child->val);
+      }
+      else if (!strcmp(child->key, "dev_pool_size"))
+      {
+         iargs->dev_pool_size = GB_TO_BYTES * atof(child->val);
+      }
+      else if (!strcmp(child->key, "uvm_pool_size"))
+      {
+         iargs->uvm_pool_size = GB_TO_BYTES * atof(child->val);
+      }
+      else if (!strcmp(child->key, "host_pool_size"))
+      {
+         iargs->host_pool_size = GB_TO_BYTES * atof(child->val);
+      }
+      else if (!strcmp(child->key, "pinned_pool_size"))
+      {
+         iargs->pinned_pool_size = GB_TO_BYTES * atof(child->val);
       }
       else
       {

--- a/src/containers.c
+++ b/src/containers.c
@@ -19,7 +19,12 @@ IntArrayCreate(size_t size)
    int_array = malloc(sizeof(IntArray));
    int_array->data = malloc(size * sizeof(int));
    int_array->size = size;
-   int_array->num_unique_entries = 0;
+
+   int_array->unique_size = 0;
+   int_array->unique_data = NULL;
+
+   int_array->g_unique_size = 0;
+   int_array->g_unique_data = NULL;
 
    return int_array;
 }
@@ -29,14 +34,26 @@ IntArrayCreate(size_t size)
  *--------------------------------------------------------------------------*/
 
 IntArray*
-IntArrayClone(IntArray* int_array_other)
+IntArrayClone(IntArray* other)
 {
-   IntArray* int_array;
+   IntArray *this;
 
-   int_array = IntArrayCreate(int_array_other->size);
-   memcpy(int_array->data, int_array_other->data, int_array->size * sizeof(int));
+   this = IntArrayCreate(other->size);
+   memcpy(this->data, other->data, other->size * sizeof(int));
 
-   return int_array;
+   if (this->unique_data)
+   {
+      memcpy(this->unique_data, other->unique_data, other->unique_size * sizeof(int));
+      this->unique_size = other->unique_size;
+   }
+
+   if (this->g_unique_data)
+   {
+      memcpy(this->g_unique_data, other->g_unique_data, other->g_unique_size * sizeof(int));
+      this->g_unique_size = other->g_unique_size;
+   }
+
+   return this;
 }
 
 /*--------------------------------------------------------------------------
@@ -46,10 +63,14 @@ IntArrayClone(IntArray* int_array_other)
 void
 IntArrayDestroy(IntArray **int_array_ptr)
 {
-   if (*int_array_ptr)
+   IntArray *this = *int_array_ptr;
+
+   if (this)
    {
-      free((*int_array_ptr)->data);
-      free(*int_array_ptr);
+      free(this->data);
+      if (this->unique_data) free(this->unique_data);
+      if (this->g_unique_data) free(this->g_unique_data);
+      free(this);
       *int_array_ptr = NULL;
    }
 }
@@ -138,68 +159,6 @@ StrToStackIntArray(const char* string, StackIntArray *int_array)
 }
 
 /*-----------------------------------------------------------------------------
- * IntArrayReadASCII
- *-----------------------------------------------------------------------------*/
-
-void
-IntArrayReadASCII(int id, const char* prefix, IntArray **array_ptr)
-{
-   char       filename[MAX_FILENAME_LENGTH];
-   int        num_entries;
-   int       *data;
-   IntArray  *array;
-   FILE      *fp;
-
-   *array_ptr = NULL;
-   sprintf(filename, "%s.%05d", prefix, id);
-   if ((fp = fopen(filename, "r")) == NULL)
-   {
-      ErrorCodeSet(ERROR_FILE_NOT_FOUND);
-      ErrorMsgAddInvalidFilename(filename);
-      return;
-   }
-
-   if (fscanf(fp, "%d", &num_entries) != 1) return;
-   array = IntArrayCreate(num_entries);
-   for (int i = 0; i < num_entries; i++)
-   {
-      if (fscanf(fp, "%d", &array->data[i]) != 1) return;
-   }
-   fclose(fp);
-
-   *array_ptr = array;
-}
-
-/*-----------------------------------------------------------------------------
- * IntArrayReadBinary
- *-----------------------------------------------------------------------------*/
-
-void
-IntArrayReadBinary(int id, const char* prefix, IntArray **array_ptr)
-{
-   char        filename[MAX_FILENAME_LENGTH];
-   size_t      num_entries;
-   IntArray   *array;
-   FILE       *fp;
-
-   *array_ptr = NULL;
-   sprintf(filename, "%s.%05d.bin", prefix, id);
-   if ((fp = fopen(filename, "rb")) == NULL)
-   {
-      ErrorCodeSet(ERROR_FILE_NOT_FOUND);
-      ErrorMsgAddInvalidFilename(filename);
-      return;
-   }
-
-   if (fscanf(fp, "%ld", &num_entries) != 1) return;
-   array = IntArrayCreate(num_entries);
-   if (fread(array->data, sizeof(int), num_entries, fp) != num_entries) return;
-   fclose(fp);
-
-   *array_ptr = array;
-}
-
-/*-----------------------------------------------------------------------------
  * IntArrayCompare
  *-----------------------------------------------------------------------------*/
 
@@ -220,43 +179,240 @@ IntArraySort(IntArray *int_array)
 }
 
 /*-----------------------------------------------------------------------------
+ * IntArrayUnique
+ *-----------------------------------------------------------------------------*/
+
+void
+IntArrayUnique(MPI_Comm comm, IntArray *int_array)
+{
+   IntArray    *tmp_array;
+   size_t       num_unique_entries;
+   int          num_entries_int;
+   int          total_num_entries;
+   int         *all_num_entries = NULL;
+   int         *displs = NULL;
+   int         *all_data = NULL;
+   int          myid, nprocs;
+
+   MPI_Comm_rank(comm, &myid);
+   MPI_Comm_rank(comm, &nprocs);
+
+   /* Sort input array */
+   tmp_array = IntArrayClone(int_array);
+   IntArraySort(tmp_array);
+
+   /* Find number of unique entries locally */
+   int_array->unique_size = 1;
+   for (size_t i = 1; i < int_array->size; i++)
+   {
+      if (tmp_array->data[i] != tmp_array->data[i - 1])
+      {
+         int_array->unique_size++;
+      }
+   }
+
+   /* Compute local unique array */
+   int_array->unique_data = (int*) calloc(int_array->unique_size, sizeof(int));
+   int_array->unique_data[0] = tmp_array->data[0];
+   for (size_t i = 1, k = 0; i < int_array->size; i++)
+   {
+      if (tmp_array->data[i] != tmp_array->data[i - 1])
+      {
+         int_array->unique_data[++k] = tmp_array->data[i];
+      }
+   }
+   IntArrayDestroy(&tmp_array);
+
+   /* Gather sizes of local unique arrays */
+   if (!myid)
+   {
+      all_num_entries = (int *) malloc(nprocs * sizeof(int));
+   }
+   num_entries_int = (int) int_array->unique_size;
+   MPI_Gather(&num_entries_int, 1, MPI_INT, all_num_entries, 1, MPI_INT, 0, comm);
+
+   /* Gather local unique arrays */
+   if (!myid)
+   {
+      displs = (int *) calloc(nprocs, sizeof(int));
+      total_num_entries = all_num_entries[0];
+      for (int i = 1; i < nprocs; i++)
+      {
+         displs[i] = displs[i - 1] + all_num_entries[i - 1];
+         total_num_entries += all_num_entries[i];
+      }
+      all_data = (int *) malloc(total_num_entries * sizeof(int));
+   }
+   MPI_Gatherv(int_array->unique_data, (int) int_array->unique_size, MPI_INT,
+               all_data, all_num_entries, displs, MPI_INT, 0, comm);
+
+   /* Compute global number of unique entries */
+   if (!myid)
+   {
+      /* Sort input array */
+      qsort(all_data, total_num_entries, sizeof(int), IntArrayCompare);
+
+      /* Find number of unique entries */
+      int_array->g_unique_size = 1;
+      for (int i = 1; i < total_num_entries; i++)
+      {
+         if (all_data[i] != all_data[i - 1])
+         {
+            int_array->g_unique_size++;
+         }
+      }
+   }
+   MPI_Bcast(&int_array->g_unique_size, 1, MPI_INT, 0, comm);
+   int_array->g_unique_data = (int*) calloc(int_array->g_unique_size, sizeof(int));
+
+   /* Compute global unique data */
+   if (!myid)
+   {
+      int_array->g_unique_data[0] = all_data[0];
+      for (size_t i = 1, k = 0; i < int_array->g_unique_size; i++)
+      {
+         if (all_data[i] != all_data[i - 1])
+         {
+            int_array->g_unique_data[++k] = all_data[i];
+         }
+      }
+      free(all_data);
+      free(all_num_entries);
+      free(displs);
+   }
+   MPI_Bcast(int_array->g_unique_data, int_array->g_unique_size, MPI_INT, 0, comm);
+}
+
+/*-----------------------------------------------------------------------------
  * IntArrayParRead
  *-----------------------------------------------------------------------------*/
 
 void
 IntArrayParRead(MPI_Comm comm, const char* prefix, IntArray **int_array_ptr)
 {
-   int        myid;
-   int        num_unique_entries;
-   IntArray  *int_array, *tmp_array;
+   char        filename[MAX_FILENAME_LENGTH];
+   char        suffix[5], code[3];
+   size_t      num_entries, num_entries_all, count;
+   IntArray   *int_array;
+   FILE       *fp;
+   int         myid, nprocs, nparts, g_nparts, offset;
+   int        *partids;
+   bool        is_binary;
 
+   *int_array_ptr = NULL;
+
+   /* 1a) Find number of parts per processor */
+   MPI_Comm_size(comm, &nprocs);
    MPI_Comm_rank(comm, &myid);
+   g_nparts = CountNumberOfPartitions(prefix);
+   nparts = g_nparts / nprocs;
+   nparts += (myid < (g_nparts % nprocs)) ? 1 : 0;
+   if (g_nparts < nprocs)
+   {
+      ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+      ErrorMsgAdd("Invalid number of parts!");
+      return;
+   }
 
+   /* 1b) Compute partids array */
+   partids = malloc(nparts * sizeof(int));
+   offset  = myid * nparts;
+   offset  += (myid < (g_nparts % nprocs)) ? myid : (g_nparts % nprocs);
+   for (int part = 0; part < nparts; part++)
+   {
+      partids[part] = offset + part;
+   }
+
+   /* Set file suffix */
    if (CheckBinaryDataExists(prefix))
    {
-      IntArrayReadBinary(myid, prefix, &int_array);
+      is_binary = true;
+      strcpy(suffix, ".bin");
+      strcpy(code, "rb");
    }
    else
    {
-      IntArrayReadASCII(myid, prefix, &int_array);
+      is_binary = false;
+      strcpy(code, "r");
+      suffix[0] = '\0';
    }
 
-   /* Find largest entry */
-   tmp_array = IntArrayClone(int_array);
-   IntArraySort(tmp_array);
-   num_unique_entries = 1;
-   for (int i = 1; i < int_array->size; i++)
+   /* Compute total number of entries considering all parts */
+   num_entries_all = 0;
+   for (int part = 0; part < nparts; part++)
    {
-      if (tmp_array->data[i] != tmp_array->data[i - 1])
+      snprintf(filename, sizeof(filename), "%s.%05d%s", prefix, partids[part], suffix);
+      if ((fp = fopen(filename, code)) == NULL)
       {
-         num_unique_entries++;
+         ErrorCodeSet(ERROR_FILE_NOT_FOUND);
+         ErrorMsgAddInvalidFilename(filename);
+         return;
       }
-   }
-   IntArrayDestroy(&tmp_array);
-   MPI_Allreduce(&num_unique_entries, &(int_array->num_unique_entries),
-                 1, MPI_INT, MPI_MAX, comm);
 
-   /* TODO - Fix num_unique_entries computation */
+      count = (is_binary) ? fread(&num_entries, sizeof(size_t), 1, fp) :
+                   (size_t) fscanf(fp, "%ld", &num_entries);
+      if (count != 1)
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Invalid number of header entries!");
+         return;
+      }
+      fclose(fp);
+      num_entries_all += num_entries;
+   }
+   int_array = IntArrayCreate(num_entries_all);
+
+   /* Fill entries */
+   for (size_t part = 0, idx = 0; part < (size_t) nparts; part++)
+   {
+      snprintf(filename, sizeof(filename), "%s.%05d%s", prefix, partids[part], suffix);
+      if ((fp = fopen(filename, code)) == NULL)
+      {
+         ErrorCodeSet(ERROR_FILE_NOT_FOUND);
+         ErrorMsgAddInvalidFilename(filename);
+         return;
+      }
+
+      count = (is_binary) ? fread(&num_entries, sizeof(size_t), 1, fp) :
+                   (size_t) fscanf(fp, "%ld", &num_entries);
+      if (count != 1)
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Invalid number of header entries!");
+         return;
+      }
+
+      if (is_binary)
+      {
+         count = fread(&int_array->data[idx], sizeof(size_t), num_entries, fp);
+      }
+      else
+      {
+         count = 0;
+         while (count < num_entries)
+         {
+            if (fscanf(fp, "%d", &int_array->data[idx + count]) != 1)
+            {
+               break;
+            }
+            count++;
+         }
+      }
+      if (count != num_entries)
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Expected %d, but found %ld coefficients!", num_entries, count);
+         return;
+      }
+
+      fclose(fp);
+      idx += num_entries;
+   }
+   free(partids);
+
+   /* Compute unique varibales */
+   IntArrayUnique(comm, int_array);
+
    *int_array_ptr = int_array;
 }
 

--- a/src/error.c
+++ b/src/error.c
@@ -196,12 +196,24 @@ ErrorCodeResetAll(void)
  *-----------------------------------------------------------------------------*/
 
 void
-ErrorMsgAdd(const char *message)
+ErrorMsgAdd(const char *format, ...)
 {
    ErrorMsgNode *new = (ErrorMsgNode *) malloc(sizeof(ErrorMsgNode));
+   va_list       args;
+   int           length;
 
-   new->message = (char *) malloc(strlen(message) + 1);
-   strcpy(new->message, message);
+   /* Determine the length of the formatted message */
+   va_start(args, format);
+   length = vsnprintf(NULL, 0, format, args);
+   va_end(args);
+
+   /* Format the message */
+   new->message = (char *) malloc(length + 1);
+   va_start(args, format);
+   vsnprintf(new->message, length + 1, format, args);
+   va_end(args);
+
+   /* Insert the new node at the head of the list */
    new->next = global_error_msg_head;
    global_error_msg_head = new;
 }

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -1,0 +1,246 @@
+/******************************************************************************
+ * Copyright (c) 2024 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "utils.h"
+#include "HYPRE_IJ_mv.h"
+
+void
+IJMatrixReadMultipartBinary(const char     *prefixname,
+                            MPI_Comm        comm,
+                            uint64_t        g_nparts,
+                            HYPRE_IJMatrix *mat_ptr)
+{
+   int               nprocs, myid;
+   uint32_t          nparts;
+   uint64_t          part;
+   uint32_t          offset;
+
+   char              filename[1024];
+   uint64_t          header[11];
+
+   uint64_t          nrows_sum, nrows_offset;
+   uint64_t          nnzs_max;
+
+   uint32_t         *partids;
+   FILE             *fp;
+
+   HYPRE_IJMatrix    mat;
+   HYPRE_BigInt      ilower, iupper;
+   HYPRE_BigInt     *rows, *cols;
+   HYPRE_Complex    *vals;
+
+   /* 1a) Find number of parts per processor */
+   MPI_Comm_size(comm, &nprocs);
+   MPI_Comm_rank(comm, &myid);
+   nparts = g_nparts / (uint64_t) nprocs;
+   nparts += (myid < ((int) g_nparts % nprocs)) ? 1 : 0;
+   if (g_nparts < (size_t) nprocs)
+   {
+      *mat_ptr = NULL;
+      ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+      ErrorMsgAdd("Invalid number of parts!");
+      return;
+   }
+
+   /* 1b) Compute partids array */
+   partids = (uint32_t*) malloc(nparts * sizeof(uint32_t));
+   offset  = ((uint32_t) myid) * nparts;
+   offset  += (myid < ((int) g_nparts % nprocs)) ? (uint32_t) myid : (uint32_t) ((int) g_nparts % nprocs);
+   for (part = 0; part < nparts; part++)
+   {
+      partids[part] = offset + part;
+   }
+
+   /* 2) Read nrows/nnz for each part */
+   nrows_sum = nnzs_max = 0;
+   for (part = 0; part < nparts; part++)
+   {
+      sprintf(filename, "%s.%05d.bin", prefixname, partids[part]);
+      fp = fopen(filename, "rb");
+      if (!fp)
+      {
+         ErrorCodeSet(ERROR_FILE_NOT_FOUND);
+         ErrorMsgAddInvalidFilename(filename);
+         fclose(fp);
+         return;
+      }
+
+      /* Read header contents */
+      if (fread(header, sizeof(uint64_t), 11, fp) != 11)
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Could not read header from %s", filename);
+         fclose(fp);
+         return;
+      }
+      fclose(fp);
+
+      nrows_sum += (uint64_t) (header[8] - header[7] + 1);
+      nnzs_max  = ((uint64_t) header[6] > nnzs_max) ? (uint64_t) header[6] : nnzs_max;
+   }
+
+   /* 3) Build IJMatrix */
+   MPI_Scan(&nrows_sum, &nrows_offset, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm);
+   ilower = (HYPRE_BigInt) (nrows_offset - nrows_sum);
+   iupper = (HYPRE_BigInt) (ilower + nrows_sum - 1);
+
+   HYPRE_IJMatrixCreate(comm, ilower, iupper, ilower, iupper, &mat);
+   HYPRE_IJMatrixSetObjectType(mat, HYPRE_PARCSR);
+   HYPRE_IJMatrixInitialize_v2(mat, HYPRE_MEMORY_HOST);
+
+   /* 4) Fill entries */
+   rows = (HYPRE_BigInt*) malloc(nnzs_max * sizeof(HYPRE_BigInt));
+   cols = (HYPRE_BigInt*) malloc(nnzs_max * sizeof(HYPRE_BigInt));
+   vals = (HYPRE_Complex*) malloc(nnzs_max * sizeof(HYPRE_Complex));
+   for (part = 0; part < nparts; part++)
+   {
+      sprintf(filename, "%s.%05d.bin", prefixname, partids[part]);
+      fp = fopen(filename, "rb");
+      fread(header, sizeof(uint64_t), 11, fp) == 11;
+
+      /* Read row and column indices */
+      if (header[1] == sizeof(HYPRE_BigInt))
+      {
+         if (fread(rows, sizeof(HYPRE_BigInt), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read row indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         if (fread(cols, sizeof(HYPRE_BigInt), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read column indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+      }
+      else if (header[1] == sizeof(uint32_t))
+      {
+         uint32_t* buffer = (uint32_t*) malloc(header[6] * sizeof(uint32_t));
+
+         if (fread(buffer, sizeof(uint32_t), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read row indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) rows[i] = (HYPRE_BigInt) buffer[i];
+
+         if (fread(buffer, sizeof(uint32_t), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read column indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) cols[i] = (HYPRE_BigInt) buffer[i];
+
+         free(buffer);
+      }
+      else if (header[1] == sizeof(uint64_t))
+      {
+         uint64_t* buffer = (uint64_t*) malloc(header[6] * sizeof(uint64_t));
+
+         if (fread(buffer, sizeof(uint64_t), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read row indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) rows[i] = (HYPRE_BigInt) buffer[i];
+
+         if (fread(buffer, sizeof(uint64_t), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read column indices from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) cols[i] = (HYPRE_BigInt) buffer[i];
+
+         free(buffer);
+      }
+      else
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Invalid row/col data type size %lld at %s", header[1], filename);
+         fclose(fp);
+         return;
+      }
+
+      /* Read matrix coefficients */
+      if (header[2] == sizeof(HYPRE_Complex))
+      {
+         if (fread(vals, sizeof(HYPRE_Complex), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+      }
+      else if (header[2] == sizeof(float))
+      {
+         float* buffer = (float*) malloc(header[6] * sizeof(float));
+
+         if (fread(buffer, sizeof(float), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) vals[i] = (HYPRE_Complex) buffer[i];
+
+         free(buffer);
+      }
+      else if (header[2] == sizeof(double))
+      {
+         double* buffer = (double*) malloc(header[6] * sizeof(double));
+
+         if (fread(buffer, sizeof(double), header[6], fp) != header[6])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[6]; i++) vals[i] = (HYPRE_Complex) buffer[i];
+
+         free(buffer);
+      }
+      else
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Invalid coefficient data type size %lld at %s", header[2], filename);
+         fclose(fp);
+         return;
+      }
+
+      HYPRE_IJMatrixSetValues(mat, (HYPRE_BigInt) header[6], NULL, rows, cols, vals);
+   }
+
+   HYPRE_IJMatrixAssemble(mat);
+   *mat_ptr = mat;
+
+   /* Free memory */
+   free(partids);
+   free(rows);
+   free(cols);
+   free(vals);
+}

--- a/src/mgr.c
+++ b/src/mgr.c
@@ -434,7 +434,7 @@ MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, HYPRE_Solver *csolver_ptr)
 
    /* Initialize variables */
    dofmap     = args->dofmap;
-   num_dofs   = dofmap->num_unique_entries;
+   num_dofs   = dofmap->g_unique_size;
    num_levels = args->num_levels;
 
    /* Compute num_c_dofs and c_dofs */
@@ -445,7 +445,7 @@ MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, HYPRE_Solver *csolver_ptr)
       c_dofs[lvl] = (HYPRE_Int*) malloc(num_dofs * sizeof(HYPRE_Int));
       num_c_dofs[lvl] = num_dofs_last - args->level[lvl].f_dofs.size;
 
-      for (i = 0; i < args->level[lvl].f_dofs.size; i++)
+      for (i = 0; i < (int) args->level[lvl].f_dofs.size; i++)
       {
          inactive_dofs[args->level[lvl].f_dofs.data[i]] = 1;
          --num_dofs_last;

--- a/src/stats.c
+++ b/src/stats.c
@@ -58,7 +58,7 @@ static Stats *global_stats = NULL;
 #define STATS_PRINT_ENTRY(_t, _n) \
    if ((_t)->num_systems < 0 || !(_n % (((_t)->counter + 1) / (_t)->num_systems))) \
    { \
-      printf("| %10ld | %11.3f | %11.3f | %11.3f | %11.2e |  %10d |\n", \
+      printf("| %10d | %11.3f | %11.3f | %11.3f | %11.2e |  %10d |\n", \
              (_n), \
              (_t)->time_factor * ((_t)->dofmap[(_n)] + (_t)->matrix[(_n)] + (_t)->rhs[(_n)]), \
              (_t)->time_factor * ((_t)->prec[(_n)]), \
@@ -68,7 +68,7 @@ static Stats *global_stats = NULL;
    } \
    else \
    { \
-      printf("| %10ld |             |", (_n)); \
+      printf("| %10d |             |", (_n)); \
       printf(" %11.3f | %11.3f | %11.2e |  %10d |\n", \
              (_t)->time_factor * ((_t)->prec[(_n)]), \
              (_t)->time_factor * ((_t)->solve[(_n)]), \
@@ -261,7 +261,7 @@ StatsPrint(int print_level)
    STATS_PRINT_DIVISOR()
 
    /* Print statistics for each entry in the array */
-   for (size_t i = 0; i < global_stats->counter + 1; i++)
+   for (int i = 0; i < global_stats->counter + 1; i++)
    {
       STATS_PRINT_ENTRY(global_stats, i);
    }

--- a/src/utils.c
+++ b/src/utils.c
@@ -62,6 +62,36 @@ CheckBinaryDataExists(const char* prefix)
 }
 
 /*-----------------------------------------------------------------------------
+ * CountNumberOfPartitions
+ *-----------------------------------------------------------------------------*/
+
+int
+CountNumberOfPartitions(const char* prefix)
+{
+   char   filename[MAX_FILENAME_LENGTH];
+   int    file_exists = 1;
+   int    num_files = 0;
+   FILE  *fp;
+
+   while (file_exists)
+   {
+      sprintf(filename, "%*s.%05d.bin", (int) strlen(prefix), prefix, num_files);
+      file_exists = ((fp = fopen(filename, "r")) == NULL) ? 0 : 1;
+      if (fp) fclose(fp);
+      if (!file_exists)
+      {
+         sprintf(filename, "%*s.%05d", (int) strlen(prefix), prefix, num_files);
+         file_exists = ((fp = fopen(filename, "r")) == NULL) ? 0 : 1;
+         if (fp) fclose(fp);
+      }
+
+      num_files++;
+   }
+
+   return --num_files;
+}
+
+/*-----------------------------------------------------------------------------
  * ComputeNumberOfDigits
  *-----------------------------------------------------------------------------*/
 

--- a/src/vector.c
+++ b/src/vector.c
@@ -1,0 +1,161 @@
+/******************************************************************************
+ * Copyright (c) 2024 Lawrence Livermore National Security, LLC and other
+ * HYPRE Project Developers. See the top-level COPYRIGHT file for details.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "utils.h"
+#include "HYPRE_IJ_mv.h"
+
+void
+IJVectorReadMultipartBinary(const char     *prefixname,
+                            MPI_Comm        comm,
+                            uint64_t        g_nparts,
+                            HYPRE_IJVector *vec_ptr)
+{
+   int               nprocs, myid;
+   uint32_t          nparts;
+   uint64_t          part;
+   uint32_t          offset;
+
+   char              filename[1024];
+   uint64_t          header[11];
+
+   uint64_t          nrows_sum, nrows_max, nrows_offset;
+
+   uint32_t         *partids;
+   FILE             *fp;
+
+   HYPRE_IJVector    vec;
+   HYPRE_BigInt      ilower, iupper;
+   HYPRE_Complex    *vals;
+
+   /* 1a) Find number of parts per processor */
+   MPI_Comm_size(comm, &nprocs);
+   MPI_Comm_rank(comm, &myid);
+   nparts = g_nparts / (uint64_t) nprocs;
+   nparts += (myid < ((int) g_nparts % nprocs)) ? 1 : 0;
+   if (g_nparts < (size_t) nprocs)
+   {
+      *vec_ptr = NULL;
+      ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+      ErrorMsgAdd("Invalid number of parts!");
+      return;
+   }
+
+   /* 1b) Compute partids array */
+   partids = (uint32_t*) malloc(nparts * sizeof(uint32_t));
+   offset  = ((uint32_t) myid) * nparts;
+   offset  += (myid < ((int) g_nparts % nprocs)) ? (uint32_t) myid : (uint32_t) ((int) g_nparts % nprocs);
+   for (part = 0; part < nparts; part++)
+   {
+      partids[part] = offset + part;
+   }
+
+   /* 2) Read nrows/nnz for each part */
+   nrows_max = nrows_sum = 0;
+   for (part = 0; part < nparts; part++)
+   {
+      sprintf(filename, "%s.%05d.bin", prefixname, partids[part]);
+      fp = fopen(filename, "rb");
+      if (!fp)
+      {
+         ErrorCodeSet(ERROR_FILE_NOT_FOUND);
+         ErrorMsgAddInvalidFilename(filename);
+         fclose(fp);
+         return;
+      }
+
+      /* Read header contents */
+      if (fread(header, sizeof(uint64_t), 8, fp) != 8)
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Could not read header from %s", filename);
+         fclose(fp);
+         return;
+      }
+      fclose(fp);
+
+      nrows_sum += header[5];
+      nrows_max = (header[5] > nrows_max) ? header[5] : nrows_max;
+   }
+
+   /* 3) Build IJVector */
+   MPI_Scan(&nrows_sum, &nrows_offset, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM, comm);
+   ilower = (HYPRE_BigInt) (nrows_offset - nrows_sum);
+   iupper = (HYPRE_BigInt) (ilower + nrows_sum - 1);
+
+   HYPRE_IJVectorCreate(comm, ilower, iupper, &vec);
+   HYPRE_IJVectorSetObjectType(vec, HYPRE_PARCSR);
+   HYPRE_IJVectorInitialize_v2(vec, HYPRE_MEMORY_HOST);
+
+   /* 4) Fill entries */
+   vals = (HYPRE_Complex*) malloc(nrows_max * sizeof(HYPRE_Complex));
+   for (part = 0; part < nparts; part++)
+   {
+      sprintf(filename, "%s.%05d.bin", prefixname, partids[part]);
+      fp = fopen(filename, "rb");
+      fread(header, sizeof(uint64_t), 8, fp) == 8;
+
+      /* Read vector coefficients */
+      if (header[1] == sizeof(HYPRE_Complex))
+      {
+         if (fread(vals, sizeof(HYPRE_Complex), header[5], fp) != header[5])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+      }
+      else if (header[1] == sizeof(float))
+      {
+         float* buffer = (float*) malloc(header[5] * sizeof(float));
+
+         if (fread(buffer, sizeof(float), header[5], fp) != header[5])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[5]; i++) vals[i] = (HYPRE_Complex) buffer[i];
+
+         free(buffer);
+      }
+      else if (header[1] == sizeof(double))
+      {
+         double* buffer = (double*) malloc(header[5] * sizeof(double));
+
+         if (fread(buffer, sizeof(double), header[5], fp) != header[5])
+         {
+            ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+            ErrorMsgAdd("Could not read coeficients from %s", filename);
+            fclose(fp);
+            return;
+         }
+
+         for (size_t i = 0; i < header[5]; i++) vals[i] = (HYPRE_Complex) buffer[i];
+
+         free(buffer);
+      }
+      else
+      {
+         ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
+         ErrorMsgAdd("Invalid coefficient data type size %lld at %s", header[1], filename);
+         fclose(fp);
+         return;
+      }
+
+      HYPRE_IJVectorSetValues(vec, (HYPRE_BigInt) header[5], NULL, vals);
+   }
+
+   HYPRE_IJVectorAssemble(vec);
+   *vec_ptr = vec;
+
+   /* Free memory */
+   free(partids);
+   free(vals);
+}


### PR DESCRIPTION
* Add umpire memory pool options to `general`
* Add `IJVectorReadMultipartBinary`
* Add `IJMatrixReadMultipartBinary`
* Add `HYPRE_ClearAllErrors` call to LS build and preconditioner setup
* Fix `dofmap` array read for distributed runs
* Update `ErrorMsgAdd` to be variadic