### PR TITLE
Add Schwarz support in MGR

### DIFF
--- a/examples/src/C_lidcavity/CMakeLists.txt
+++ b/examples/src/C_lidcavity/CMakeLists.txt
@@ -75,6 +75,20 @@ if(HYPREDRV_ENABLE_TESTING)
                 "Path"
                 "1.1.1"
         )
+        if(HYPREDRV_ENABLE_EXPERIMENTAL)
+            add_executable_test(lidcavity_test_schwarz_ras_iluk_1proc lidcavity 1
+                ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                     -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-schwarz-ras-iluk.yml
+                RUN_SERIAL
+            )
+            if(HYPREDRV_HAVE_HYPRE_USING_DSUPERLU)
+                add_executable_test(lidcavity_test_schwarz_ras_spdirect_1proc lidcavity 1
+                    ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                         -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-schwarz-ras-spdirect.yml
+                    RUN_SERIAL
+                )
+            endif()
+        endif()
     endif()
     if(HYPREDRV_HAVE_HYPRE_30100_DEV5)
         add_executable_test(lidcavity_test_mgr_1proc lidcavity 1
@@ -102,6 +116,30 @@ if(HYPREDRV_ENABLE_TESTING)
         )
         hypredrv_append_test_environment(lidcavity_test_adaptive_reuse_1proc
             "HYPREDRV_LOG_LEVEL=2")
+        if(HYPREDRV_ENABLE_EXPERIMENTAL)
+            add_executable_test(lidcavity_test_mgr_schwarz_frelax_iluk_1proc lidcavity 1
+                ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                     -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-frelax-iluk.yml
+                RUN_SERIAL
+            )
+            add_executable_test(lidcavity_test_mgr_schwarz_grelax_iluk_1proc lidcavity 1
+                ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                     -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-grelax-iluk.yml
+                RUN_SERIAL
+            )
+            add_executable_test(lidcavity_test_mgr_schwarz_coarsest_iluk_1proc lidcavity 1
+                ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                     -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-coarsest-iluk.yml
+                RUN_SERIAL
+            )
+            if(HYPREDRV_HAVE_HYPRE_USING_DSUPERLU)
+                add_executable_test(lidcavity_test_mgr_schwarz_frelax_spdirect_1proc lidcavity 1
+                    ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
+                         -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-frelax-spdirect.yml
+                    RUN_SERIAL
+                )
+            endif()
+        endif()
         if(HYPREDRV_HAVE_HYPRE_DEVELOP_NUMBER)
             add_executable_test(lidcavity_test_mgr_4proc lidcavity 4
               ARGS -v 1 -n 12 12 -P 2 2 -ns 1 -dt 0.1 -tf 0.3 -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr.yml

--- a/examples/src/C_lidcavity/CMakeLists.txt
+++ b/examples/src/C_lidcavity/CMakeLists.txt
@@ -132,12 +132,32 @@ if(HYPREDRV_ENABLE_TESTING)
                      -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-coarsest-iluk.yml
                 RUN_SERIAL
             )
+            if(HYPREDRV_HAVE_HYPRE_DEVELOP_NUMBER)
+                add_executable_test(lidcavity_test_mgr_schwarz_frelax_iluk_4proc lidcavity 4
+                    ARGS -v 1 -n 12 12 -P 2 2 -ns 1 -dt 0.1 -tf 0.3
+                         -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-frelax-iluk.yml
+                )
+                add_executable_test(lidcavity_test_mgr_schwarz_grelax_iluk_4proc lidcavity 4
+                    ARGS -v 1 -n 12 12 -P 2 2 -ns 1 -dt 0.1 -tf 0.3
+                         -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-grelax-iluk.yml
+                )
+                add_executable_test(lidcavity_test_mgr_schwarz_coarsest_iluk_4proc lidcavity 4
+                    ARGS -v 1 -n 12 12 -P 2 2 -ns 1 -dt 0.1 -tf 0.3
+                         -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-coarsest-iluk.yml
+                )
+            endif()
             if(HYPREDRV_HAVE_HYPRE_USING_DSUPERLU)
                 add_executable_test(lidcavity_test_mgr_schwarz_frelax_spdirect_1proc lidcavity 1
                     ARGS -v 1 -n 12 12 -ns 1 -dt 0.1 -tf 0.3
                          -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-frelax-spdirect.yml
                     RUN_SERIAL
                 )
+                if(HYPREDRV_HAVE_HYPRE_DEVELOP_NUMBER)
+                    add_executable_test(lidcavity_test_mgr_schwarz_frelax_spdirect_4proc lidcavity 4
+                        ARGS -v 1 -n 12 12 -P 2 2 -ns 1 -dt 0.1 -tf 0.3
+                             -i ${CMAKE_CURRENT_SOURCE_DIR}/fgmres-mgr-schwarz-frelax-spdirect.yml
+                    )
+                endif()
             endif()
         endif()
         if(HYPREDRV_HAVE_HYPRE_DEVELOP_NUMBER)

--- a/examples/src/C_lidcavity/fgmres-mgr-schwarz-coarsest-iluk.yml
+++ b/examples/src/C_lidcavity/fgmres-mgr-schwarz-coarsest-iluk.yml
@@ -1,0 +1,40 @@
+linear_system:
+  dof_labels:
+    v_x: 0
+    v_y: 1
+    p:   2
+
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 200
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  mgr:
+    tolerance: 0.0
+    max_iter: 1
+    print_level: 0
+    coarse_th: 0.0
+    level:
+      0:
+        f_dofs: [v_x, v_y]
+        f_relaxation:
+          amg:
+            print_level: 0
+            max_iter: 1
+            coarsening:
+              strong_th: 0.5
+              num_functions: 2
+        g_relaxation: none
+        restriction_type: injection
+        prolongation_type: blk-absrowsum
+        coarse_level_type: galerkin
+
+    coarsest_level:
+      schwarz:
+        variant: ras-iluk
+        overlap: 1
+        max_iter: 1
+        print_level: 0

--- a/examples/src/C_lidcavity/fgmres-mgr-schwarz-frelax-iluk.yml
+++ b/examples/src/C_lidcavity/fgmres-mgr-schwarz-frelax-iluk.yml
@@ -1,0 +1,40 @@
+linear_system:
+  dof_labels:
+    v_x: 0
+    v_y: 1
+    p:   2
+
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 200
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  mgr:
+    tolerance: 0.0
+    max_iter: 1
+    print_level: 0
+    coarse_th: 0.0
+    level:
+      0:
+        f_dofs: [v_x, v_y]
+        f_relaxation:
+          schwarz:
+            variant: ras-iluk
+            overlap: 1
+            max_iter: 1
+            print_level: 0
+        g_relaxation: none
+        restriction_type: injection
+        prolongation_type: blk-absrowsum
+        coarse_level_type: galerkin
+
+    coarsest_level:
+      amg:
+        max_iter: 1
+        print_level: 0
+        coarsening:
+          strong_th: 0.9
+          num_functions: 1

--- a/examples/src/C_lidcavity/fgmres-mgr-schwarz-frelax-spdirect.yml
+++ b/examples/src/C_lidcavity/fgmres-mgr-schwarz-frelax-spdirect.yml
@@ -1,0 +1,40 @@
+linear_system:
+  dof_labels:
+    v_x: 0
+    v_y: 1
+    p:   2
+
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 200
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  mgr:
+    tolerance: 0.0
+    max_iter: 1
+    print_level: 0
+    coarse_th: 0.0
+    level:
+      0:
+        f_dofs: [v_x, v_y]
+        f_relaxation:
+          schwarz:
+            variant: ras-spdirect
+            overlap: 1
+            max_iter: 1
+            print_level: 0
+        g_relaxation: none
+        restriction_type: injection
+        prolongation_type: blk-absrowsum
+        coarse_level_type: galerkin
+
+    coarsest_level:
+      amg:
+        max_iter: 1
+        print_level: 0
+        coarsening:
+          strong_th: 0.9
+          num_functions: 1

--- a/examples/src/C_lidcavity/fgmres-mgr-schwarz-grelax-iluk.yml
+++ b/examples/src/C_lidcavity/fgmres-mgr-schwarz-grelax-iluk.yml
@@ -1,0 +1,46 @@
+linear_system:
+  dof_labels:
+    v_x: 0
+    v_y: 1
+    p:   2
+
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 200
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  mgr:
+    tolerance: 0.0
+    max_iter: 1
+    print_level: 0
+    coarse_th: 0.0
+    level:
+      0:
+        f_dofs: [v_x, v_y]
+        f_relaxation:
+          amg:
+            print_level: 0
+            max_iter: 1
+            coarsening:
+              strong_th: 0.5
+              num_functions: 2
+        g_relaxation:
+          schwarz:
+            variant: ras-iluk
+            overlap: 1
+            max_iter: 1
+            print_level: 0
+        restriction_type: injection
+        prolongation_type: blk-absrowsum
+        coarse_level_type: galerkin
+
+    coarsest_level:
+      amg:
+        max_iter: 1
+        print_level: 0
+        coarsening:
+          strong_th: 0.9
+          num_functions: 1

--- a/examples/src/C_lidcavity/fgmres-schwarz-ras-iluk.yml
+++ b/examples/src/C_lidcavity/fgmres-schwarz-ras-iluk.yml
@@ -1,0 +1,13 @@
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 100
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  schwarz:
+    variant: ras-iluk
+    overlap: 1
+    max_iter: 1
+    print_level: 0

--- a/examples/src/C_lidcavity/fgmres-schwarz-ras-spdirect.yml
+++ b/examples/src/C_lidcavity/fgmres-schwarz-ras-spdirect.yml
@@ -1,0 +1,13 @@
+solver:
+  fgmres:
+    max_iter: 200
+    krylov_dim: 100
+    print_level: 0
+    relative_tol: 1.0e-6
+
+preconditioner:
+  schwarz:
+    variant: ras-spdirect
+    overlap: 1
+    max_iter: 1
+    print_level: 0

--- a/include/HYPREDRV_utils.h
+++ b/include/HYPREDRV_utils.h
@@ -29,11 +29,12 @@
 
 #include "HYPREDRV.h"
 
+#ifndef HYPREDRV_SAFE_CALL_HANDLE_ERROR_DECLARED
+#define HYPREDRV_SAFE_CALL_HANDLE_ERROR_DECLARED
 HYPREDRV_EXPORT_SYMBOL void hypredrv_SafeCallHandleError(uint32_t error_code,
-                                                         MPI_Comm comm,
-                                                         const char *file,
-                                                         int line,
-                                                         const char *func);
+                                                         MPI_Comm comm, const char *file,
+                                                         int line, const char *func);
+#endif
 
 /**
  * @brief Safely call a HYPREDRV function; abort on error via MPI_COMM_WORLD.

--- a/include/HYPREDRV_utils.h
+++ b/include/HYPREDRV_utils.h
@@ -15,9 +15,9 @@
  *
  * Include this header after HYPREDRV.h when you want to use the
  * HYPREDRV_SAFE_CALL or HYPREDRV_SAFE_CALL_COMM convenience macros.
- * These macros are kept in a separate header to avoid leaking system
- * symbols (strcmp, getenv, raise, ...) into translation units that only
- * need the public HYPREDRV API types and function declarations.
+ * These macros are kept in a separate header so translation units that only need
+ * the public HYPREDRV API types and function declarations do not also receive
+ * abort-on-error convenience macros.
  *
  * @code
  *   #include <HYPREDRV.h>
@@ -26,34 +26,14 @@
  */
 
 #include <mpi.h>
-#include <signal.h> // For: raise
-#include <stdio.h>  // For: fprintf
-#include <stdlib.h> // For: getenv
-#include <string.h> // For: strcmp
 
 #include "HYPREDRV.h"
 
-static inline void
-hypredrv_SafeCallHandleError(uint32_t error_code, MPI_Comm comm, const char *file,
-                             int line, const char *func)
-{
-   /* GCOVR_EXCL_BR_START */
-   if (error_code != 0)
-   {
-      (void)fprintf(stderr, "At %s:%d in %s():\n", file, line, func);
-      HYPREDRV_ErrorCodeDescribe(error_code);
-      const char *debug_env = getenv("HYPREDRV_DEBUG");
-      if (debug_env && strcmp(debug_env, "1") == 0)
-      {
-         raise(SIGTRAP); /* Breakpoint for gdb */
-      }
-      else
-      {
-         MPI_Abort(comm, (int)error_code);
-      }
-   }
-   /* GCOVR_EXCL_BR_STOP */
-}
+HYPREDRV_EXPORT_SYMBOL void hypredrv_SafeCallHandleError(uint32_t error_code,
+                                                         MPI_Comm comm,
+                                                         const char *file,
+                                                         int line,
+                                                         const char *func);
 
 /**
  * @brief Safely call a HYPREDRV function; abort on error via MPI_COMM_WORLD.

--- a/include/internal/error.h
+++ b/include/internal/error.h
@@ -83,7 +83,10 @@ void hypredrv_ErrorMsgAddInvalidFilename(const char *);
 void hypredrv_ErrorMsgPrint(void);
 void hypredrv_ErrorMsgClear(void);
 void hypredrv_ErrorBacktracePrint(void);
+#ifndef HYPREDRV_SAFE_CALL_HANDLE_ERROR_DECLARED
+#define HYPREDRV_SAFE_CALL_HANDLE_ERROR_DECLARED
 void hypredrv_SafeCallHandleError(uint32_t, MPI_Comm, const char *, int, const char *);
+#endif
 
 /*******************************************************************************
  *******************************************************************************/

--- a/include/internal/error.h
+++ b/include/internal/error.h
@@ -66,6 +66,8 @@ void     hypredrv_ErrorCodeDescribe(uint32_t);
 void     hypredrv_ErrorCodeReset(uint32_t);
 void     hypredrv_ErrorCodeResetAll(void);
 void     hypredrv_ErrorStateReset(void);
+void     hypredrv_ErrorReportSetCollective(bool collective);
+bool     hypredrv_ErrorReportIsCollective(void);
 bool     hypredrv_DistributedErrorCodeActive(MPI_Comm);
 bool     hypredrv_DistributedErrorStateSync(MPI_Comm);
 
@@ -81,6 +83,7 @@ void hypredrv_ErrorMsgAddInvalidFilename(const char *);
 void hypredrv_ErrorMsgPrint(void);
 void hypredrv_ErrorMsgClear(void);
 void hypredrv_ErrorBacktracePrint(void);
+void hypredrv_SafeCallHandleError(uint32_t, MPI_Comm, const char *, int, const char *);
 
 /*******************************************************************************
  *******************************************************************************/

--- a/include/internal/mgr.h
+++ b/include/internal/mgr.h
@@ -9,10 +9,14 @@
 #define MGR_HEADER
 
 #include "internal/amg.h"
+#include "internal/compatibility.h"
 #include "internal/containers.h"
 #include "internal/fsai.h"
 #include "internal/ilu.h"
 #include "internal/precon_reuse.h"
+#if HYPREDRV_HAVE_EXPERIMENTAL
+#include "internal/schwarz.h"
+#endif
 #include "internal/utils.h"
 
 struct NestedKrylov_args_struct;
@@ -21,8 +25,18 @@ typedef struct MGR_args_struct MGR_args;
 
 enum
 {
-   MAX_MGR_LEVELS           = 32,
-   MGR_FRLX_TYPE_NESTED_MGR = 202,
+   MAX_MGR_LEVELS = 32,
+
+   /* hypre's level-0 custom F-solver callback path is keyed through AMG's
+    * F-relaxation type. We use it for wrapped Schwarz F-relaxation because it
+    * keeps hypre's extracted A_FF matrix alive through setup and solve. */
+   MGR_FRLX_TYPE_CUSTOM_SOLVER_CB = 2,
+   MGR_FRLX_TYPE_NESTED_MGR       = 202,
+
+   /* Disable hypre's built-in global smoother slot when a user smoother is
+    * installed via HYPRE_MGRSetGlobalSmootherAtLevel. */
+   MGR_GRLX_TYPE_USER_SMOOTHER = -1,
+   MGR_SOLVER_TYPE_SCHWARZ     = 34,
 };
 
 typedef struct MGRComponentReuse_args_struct
@@ -53,6 +67,9 @@ typedef struct MGRcls_args_struct
       AMG_args  amg;
       ILU_args  ilu;
       FSAI_args fsai;
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      Schwarz_args schwarz;
+#endif
    };
 } MGRcls_args;
 
@@ -76,6 +93,9 @@ typedef struct MGRfrlx_args_struct
       AMG_args  amg;
       ILU_args  ilu;
       FSAI_args fsai;
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      Schwarz_args schwarz;
+#endif
    };
 } MGRfrlx_args;
 
@@ -98,6 +118,9 @@ typedef struct MGRgrlx_args_struct
       AMG_args  amg;
       ILU_args  ilu;
       FSAI_args fsai;
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      Schwarz_args schwarz;
+#endif
    };
 } MGRgrlx_args;
 

--- a/src/HYPREDRV.c
+++ b/src/HYPREDRV.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "_hypre_parcsr_mv.h" /* For hypre_VectorData, hypre_ParVectorLocalVector */
 #include "internal/args.h"
@@ -783,9 +784,6 @@ HYPREDRV_ErrorCodeDescribe(uint32_t error_code)
    hypredrv_ErrorMsgClear();
    hypredrv_ErrorBacktracePrint();
 }
-
-/*-----------------------------------------------------------------------------
- *-----------------------------------------------------------------------------*/
 
 static uint32_t
 DestroyObjectInternal(HYPREDRV_t hypredrv)

--- a/src/args.c
+++ b/src/args.c
@@ -1277,13 +1277,6 @@ LoadResolvedConfigPath(const char *candidate, char *cfg_path, size_t cfg_path_si
       hypredrv_ErrorMsgAdd("Invalid configuration file path");
       return false;
    }
-   if (!hypredrv_BinaryPathPrefixIsSafe(candidate) || strstr(candidate, "..") != NULL)
-   {
-      hypredrv_ErrorCodeSet(ERROR_FILE_UNEXPECTED_ENTRY);
-      hypredrv_ErrorMsgAdd("Invalid configuration file path");
-      return false;
-   }
-
    hypredrv_SplitFilename(candidate, &dirname, &basename);
    if (!dirname || !basename || basename[0] == '\0')
    {

--- a/src/args.c
+++ b/src/args.c
@@ -1443,6 +1443,8 @@ hypredrv_InputArgsParseWithObjectName(MPI_Comm comm, bool lib_mode, int argc, ch
    const int config_idx = FindConfigIndex(argc, argv);
    if (!LoadConfigText(comm, argc, argv, config_idx, &base_indent, &text, &config_dir))
    {
+      (void)hypredrv_DistributedErrorStateSync(comm);
+      hypredrv_ErrorReportSetCollective(true);
       *args_ptr = NULL;
       HYPREDRV_LOGF(2, myid, log_object_name, 0,
                     "args parse failed while loading config text");
@@ -1468,10 +1470,14 @@ hypredrv_InputArgsParseWithObjectName(MPI_Comm comm, bool lib_mode, int argc, ch
    HYPREDRV_LOGF(3, myid, log_object_name, 0, "yaml CLI overrides applied");
 
    /* Return earlier if YAML tree was not built properly */
-   if (!myid && hypredrv_ErrorCodeActive())
+   if (hypredrv_DistributedErrorStateSync(comm))
    {
-      hypredrv_YAMLtreePrint(tree, YAML_PRINT_MODE_ANY);
       hypredrv_ErrorCodeSet(ERROR_YAML_TREE_INVALID);
+      hypredrv_ErrorReportSetCollective(true);
+      if (!myid)
+      {
+         hypredrv_YAMLtreePrint(tree, YAML_PRINT_MODE_ANY);
+      }
       free(text);
       free(config_dir);
       hypredrv_YAMLtreeDestroy(&tree);
@@ -1500,10 +1506,14 @@ hypredrv_InputArgsParseWithObjectName(MPI_Comm comm, bool lib_mode, int argc, ch
    hypredrv_YAMLtreeValidate(tree);
 
    /* Return earlier if YAML tree is invalid */
-   if (!myid && hypredrv_ErrorCodeActive())
+   if (hypredrv_DistributedErrorStateSync(comm))
    {
-      hypredrv_YAMLtreePrint(tree, YAML_PRINT_MODE_ANY);
       hypredrv_ErrorCodeSet(ERROR_YAML_TREE_INVALID);
+      hypredrv_ErrorReportSetCollective(true);
+      if (!myid)
+      {
+         hypredrv_YAMLtreePrint(tree, YAML_PRINT_MODE_ANY);
+      }
       hypredrv_InputArgsDestroy(&iargs);
       hypredrv_YAMLtreeDestroy(&tree);
       HYPREDRV_LOGF(2, myid, log_object_name, 0,

--- a/src/error.c
+++ b/src/error.c
@@ -437,7 +437,7 @@ hypredrv_ErrorBacktracePrint(void)
       // cppcheck-suppress unreachableCode
       waitpid(child_pid, NULL, 0);
    }
-   /* GCOVR_EXCL_BR_STOP */
+   /* GCOVR_EXCL_STOP */
 }
 
 #else
@@ -638,10 +638,11 @@ hypredrv_SafeCallHandleError(uint32_t error_code, MPI_Comm comm, const char *fil
       else
       {
          MPI_Abort(comm, (int)error_code);
+         /* Defensive fallback for non-conforming or mocked MPI runtimes that return. */
          exit((int)error_code);
       }
    }
-   /* GCOVR_EXCL_STOP */
+   /* GCOVR_EXCL_BR_STOP */
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/error.c
+++ b/src/error.c
@@ -7,6 +7,7 @@
 
 #include "internal/error.h"
 #include <limits.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,7 +17,6 @@
 #include <errno.h>
 #include <execinfo.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -437,7 +437,7 @@ hypredrv_ErrorBacktracePrint(void)
       // cppcheck-suppress unreachableCode
       waitpid(child_pid, NULL, 0);
    }
-   /* GCOVR_EXCL_STOP */
+   /* GCOVR_EXCL_BR_STOP */
 }
 
 #else
@@ -475,6 +475,7 @@ typedef struct ErrorState
    uint32_t      code_count[ERROR_CODE_NUM_ENTRIES];
    ErrorMsgNode *msg_head;
    uint32_t      dropped_msg_count;
+   bool          collective_report;
 } ErrorState;
 
 static ErrorState global_error_state = {0};
@@ -575,6 +576,72 @@ bool
 hypredrv_ErrorCodeActive(void)
 {
    return (ErrorStateGet()->code != ERROR_NONE);
+}
+
+/*-----------------------------------------------------------------------------
+ * hypredrv_ErrorReportSetCollective
+ *-----------------------------------------------------------------------------*/
+
+void
+hypredrv_ErrorReportSetCollective(bool collective)
+{
+   ErrorStateGet()->collective_report = collective;
+}
+
+/*-----------------------------------------------------------------------------
+ * hypredrv_ErrorReportIsCollective
+ *-----------------------------------------------------------------------------*/
+
+bool
+hypredrv_ErrorReportIsCollective(void)
+{
+   return ErrorStateGet()->collective_report;
+}
+
+/*-----------------------------------------------------------------------------
+ * hypredrv_SafeCallHandleError
+ *-----------------------------------------------------------------------------*/
+
+void
+hypredrv_SafeCallHandleError(uint32_t error_code, MPI_Comm comm, const char *file,
+                             int line, const char *func)
+{
+   /* GCOVR_EXCL_BR_START */
+   if (error_code != 0)
+   {
+      bool collective_report = hypredrv_ErrorReportIsCollective();
+      bool describe_error    = true;
+      if (collective_report)
+      {
+         int myid = 0;
+         MPI_Comm_rank(comm, &myid);
+         describe_error = (myid == 0);
+      }
+
+      if (describe_error)
+      {
+         (void)fprintf(stderr, "At %s:%d in %s():\n", file, line, func);
+         hypredrv_ErrorCodeDescribe(error_code);
+         hypredrv_ErrorMsgPrint();
+         hypredrv_ErrorMsgClear();
+         hypredrv_ErrorBacktracePrint();
+      }
+      if (collective_report)
+      {
+         MPI_Barrier(comm);
+      }
+      const char *debug_env = getenv("HYPREDRV_DEBUG");
+      if (debug_env && strcmp(debug_env, "1") == 0)
+      {
+         raise(SIGTRAP); /* Breakpoint for gdb */
+      }
+      else
+      {
+         MPI_Abort(comm, (int)error_code);
+         exit((int)error_code);
+      }
+   }
+   /* GCOVR_EXCL_STOP */
 }
 
 /*-----------------------------------------------------------------------------
@@ -691,7 +758,6 @@ ErrorStateApplySynchronized(ErrorState *state, uint32_t code, uint32_t source_co
          state->code_count[i] = 1;
       }
    }
-
    if (serialized && serialized[0] != '\0')
    {
       text = strdup(serialized);
@@ -896,6 +962,7 @@ hypredrv_ErrorCodeResetAll(void)
 {
    /* Clear *all* bits, including ERROR_UNKNOWN (0x80000000). */
    hypredrv_ErrorCodeReset(0xFFFFFFFFu);
+   ErrorStateGet()->collective_report = false;
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/mgr.c
+++ b/src/mgr.c
@@ -7,6 +7,7 @@
 
 #include "internal/mgr.h"
 #include <mpi.h>
+#include <stddef.h>
 /* gcovr: branch-exclusion regions below narrow branch-count noise from YAML
  * helpers and MGR validation/dispatch; single-line exclusions flag allocator
  * and defensive branches that are impractical to fault-inject here. */
@@ -30,6 +31,30 @@ typedef struct MGRFRelaxWrapper_struct
    IntArray                       *owned_dofmap;
    struct MGRFRelaxWrapper_struct *next_live;
 } MGRFRelaxWrapper;
+
+#if HYPREDRV_HAVE_EXPERIMENTAL
+typedef struct MGRSchwarzWrapper_struct
+{
+   /* Keep the first fields layout-compatible with hypre_Solver as validated
+    * against the hypre 3.1 development stream used by the Schwarz branch. */
+   HYPRE_PtrToSolverFcn  setup;
+   HYPRE_PtrToSolverFcn  solve;
+   HYPRE_PtrToDestroyFcn destroy;
+   HYPRE_Int             is_setup;
+   HYPRE_Solver          inner;
+} MGRSchwarzWrapper;
+
+enum
+{
+   MGR_HYPRE_SOLVER_IS_SETUP_OFFSET =
+      sizeof(HYPRE_PtrToSolverFcn) + sizeof(HYPRE_PtrToSolverFcn) +
+      sizeof(HYPRE_PtrToDestroyFcn),
+};
+
+typedef char MGRSchwarzWrapperLayoutCheck
+   [(offsetof(MGRSchwarzWrapper, is_setup) == MGR_HYPRE_SOLVER_IS_SETUP_OFFSET) ? 1 :
+                                                                                  -1];
+#endif
 
 static MGRFRelaxWrapper *g_mgr_frelax_wrapper_live_head = NULL;
 
@@ -224,6 +249,108 @@ hypredrv_MGRNestedFRelaxWrapperFree(HYPRE_Solver *wrapper_ptr)
    MGRFRelaxWrapperDestroy((void *)(*wrapper_ptr));
    *wrapper_ptr = NULL;
 }
+
+#if HYPREDRV_HAVE_EXPERIMENTAL
+static HYPRE_Int
+MGRSchwarzWrapperSetup(HYPRE_Solver wrapper_v, HYPRE_Matrix A, HYPRE_Vector b,
+                       HYPRE_Vector x)
+{
+   MGRSchwarzWrapper *wrapper = (MGRSchwarzWrapper *)wrapper_v;
+   if (!wrapper || !wrapper->inner)
+   {
+      return 1;
+   }
+
+   if (HYPRE_SchwarzSetup((HYPRE_Solver)wrapper->inner, (HYPRE_ParCSRMatrix)A,
+                          (HYPRE_ParVector)b, (HYPRE_ParVector)x))
+   {
+      return 1;
+   }
+
+   wrapper->is_setup = 1;
+   return 0;
+}
+
+static HYPRE_Int
+MGRSchwarzWrapperSolve(HYPRE_Solver wrapper_v, HYPRE_Matrix A, HYPRE_Vector b,
+                       HYPRE_Vector x)
+{
+   MGRSchwarzWrapper *wrapper = (MGRSchwarzWrapper *)wrapper_v;
+   if (!wrapper || !wrapper->inner)
+   {
+      return 1;
+   }
+
+   if (!wrapper->is_setup &&
+       MGRSchwarzWrapperSetup(wrapper_v, A, b, x))
+   {
+      return 1;
+   }
+
+   return HYPRE_SchwarzSolve((HYPRE_Solver)wrapper->inner, (HYPRE_ParCSRMatrix)A,
+                             (HYPRE_ParVector)b, (HYPRE_ParVector)x);
+}
+
+static HYPRE_Int
+MGRSchwarzWrapperDestroy(HYPRE_Solver wrapper_v)
+{
+   MGRSchwarzWrapper *wrapper = (MGRSchwarzWrapper *)wrapper_v;
+   if (!wrapper)
+   {
+      return 0;
+   }
+
+   if (wrapper->inner)
+   {
+      HYPRE_SchwarzDestroy(wrapper->inner);
+      wrapper->inner = NULL;
+   }
+   free(wrapper);
+   return 0;
+}
+
+static HYPRE_Int
+MGRSchwarzWrapperParSetup(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A,
+                          HYPRE_ParVector b, HYPRE_ParVector x)
+{
+   return MGRSchwarzWrapperSetup(wrapper, (HYPRE_Matrix)A, (HYPRE_Vector)b,
+                                 (HYPRE_Vector)x);
+}
+
+static HYPRE_Int
+MGRSchwarzWrapperParSolve(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A,
+                          HYPRE_ParVector b, HYPRE_ParVector x)
+{
+   return MGRSchwarzWrapperSolve(wrapper, (HYPRE_Matrix)A, (HYPRE_Vector)b,
+                                 (HYPRE_Vector)x);
+}
+
+static HYPRE_Solver
+MGRSchwarzWrapperCreate(const Schwarz_args *args)
+{
+   HYPRE_Solver       inner   = NULL;
+   MGRSchwarzWrapper *wrapper = (MGRSchwarzWrapper *)calloc(1, sizeof(*wrapper));
+   if (!wrapper)
+   {
+      hypredrv_ErrorCodeSet(ERROR_ALLOCATION);
+      hypredrv_ErrorMsgAdd("Failed to allocate MGR Schwarz solver wrapper");
+      return NULL;
+   }
+
+   hypredrv_SchwarzCreate(args, &inner);
+   if (hypredrv_ErrorCodeActive() || !inner)
+   {
+      free(wrapper);
+      return NULL;
+   }
+
+   wrapper->setup   = MGRSchwarzWrapperSetup;
+   wrapper->solve   = MGRSchwarzWrapperSolve;
+   wrapper->destroy = MGRSchwarzWrapperDestroy;
+   wrapper->inner   = inner;
+   return (HYPRE_Solver)wrapper;
+}
+#endif
 /* GCOVR_EXCL_STOP */
 
 /*-----------------------------------------------------------------------------
@@ -352,29 +479,53 @@ DEFINE_TYPED_SETTER(MGRfrlxFSAISetArgs, MGRfrlx_args, fsai, 33, hypredrv_FSAISet
 DEFINE_TYPED_SETTER(MGRgrlxAMGSetArgs, MGRgrlx_args, amg, 20, hypredrv_AMGSetArgs)
 DEFINE_TYPED_SETTER(MGRgrlxILUSetArgs, MGRgrlx_args, ilu, 16, hypredrv_ILUSetArgs)
 DEFINE_TYPED_SETTER(MGRgrlxFSAISetArgs, MGRgrlx_args, fsai, 33, hypredrv_FSAISetArgs)
+#if HYPREDRV_HAVE_EXPERIMENTAL
+DEFINE_TYPED_SETTER(MGRclsSchwarzSetArgs, MGRcls_args, schwarz, MGR_SOLVER_TYPE_SCHWARZ,
+                    hypredrv_SchwarzSetArgs)
+DEFINE_TYPED_SETTER(MGRfrlxSchwarzSetArgs, MGRfrlx_args, schwarz,
+                    MGR_SOLVER_TYPE_SCHWARZ, hypredrv_SchwarzSetArgs)
+DEFINE_TYPED_SETTER(MGRgrlxSchwarzSetArgs, MGRgrlx_args, schwarz,
+                    MGR_SOLVER_TYPE_SCHWARZ, hypredrv_SchwarzSetArgs)
+#endif
 static void MGRfrlxMGRSetArgs(void *, const YAMLnode *);
 void        hypredrv_MGRSetArgsFromYAML(void *, YAMLnode *);
 
-#define MGRcls_FIELDS(_prefix)                                     \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet) \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRclsAMGSetArgs)          \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRclsILUSetArgs)          \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRclsFSAISetArgs)
+#if HYPREDRV_HAVE_EXPERIMENTAL
+#define MGRcls_SCHWARZ_FIELD(_prefix) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, schwarz, MGRclsSchwarzSetArgs)
+#define MGRfrlx_SCHWARZ_FIELD(_prefix) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, schwarz, MGRfrlxSchwarzSetArgs)
+#define MGRgrlx_SCHWARZ_FIELD(_prefix) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, schwarz, MGRgrlxSchwarzSetArgs)
+#else
+#define MGRcls_SCHWARZ_FIELD(_prefix)
+#define MGRfrlx_SCHWARZ_FIELD(_prefix)
+#define MGRgrlx_SCHWARZ_FIELD(_prefix)
+#endif
 
-#define MGRfrlx_FIELDS(_prefix)                                          \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)       \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet) \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, mgr, MGRfrlxMGRSetArgs)               \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRfrlxAMGSetArgs)               \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRfrlxILUSetArgs)               \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRfrlxFSAISetArgs)
+#define MGRcls_FIELDS(_prefix)                                      \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)  \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRclsAMGSetArgs)           \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRclsILUSetArgs)           \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRclsFSAISetArgs)         \
+   MGRcls_SCHWARZ_FIELD(_prefix)
 
-#define MGRgrlx_FIELDS(_prefix)                                          \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)       \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet) \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRgrlxAMGSetArgs)               \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRgrlxILUSetArgs)               \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRgrlxFSAISetArgs)
+#define MGRfrlx_FIELDS(_prefix)                                           \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)        \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet)  \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, mgr, MGRfrlxMGRSetArgs)                \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRfrlxAMGSetArgs)                \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRfrlxILUSetArgs)                \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRfrlxFSAISetArgs)              \
+   MGRfrlx_SCHWARZ_FIELD(_prefix)
+
+#define MGRgrlx_FIELDS(_prefix)                                           \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)        \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet)  \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRgrlxAMGSetArgs)                \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRgrlxILUSetArgs)                \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRgrlxFSAISetArgs)              \
+   MGRgrlx_SCHWARZ_FIELD(_prefix)
 
 #define MGRlvl_FIELDS(_prefix)                                                  \
    ADD_FIELD_OFFSET_ENTRY(_prefix, f_dofs, MGRlvlFDofsSet)                      \
@@ -831,6 +982,12 @@ MGRclsApplyTypeDefaults(MGRcls_args *args, HYPRE_Int old_type)
    {
       hypredrv_ILUSetDefaultArgs(&args->ilu);
    }
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (args->type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      hypredrv_SchwarzSetDefaultArgs(&args->schwarz);
+   }
+#endif
 }
 
 static void
@@ -849,6 +1006,12 @@ MGRfrlxApplyTypeDefaults(MGRfrlx_args *args, HYPRE_Int old_type)
    {
       hypredrv_ILUSetDefaultArgs(&args->ilu);
    }
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (args->type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      hypredrv_SchwarzSetDefaultArgs(&args->schwarz);
+   }
+#endif
 }
 
 static void
@@ -867,6 +1030,12 @@ MGRgrlxApplyTypeDefaults(MGRgrlx_args *args, HYPRE_Int old_type)
    {
       hypredrv_ILUSetDefaultArgs(&args->ilu);
    }
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (args->type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      hypredrv_SchwarzSetDefaultArgs(&args->schwarz);
+   }
+#endif
 }
 
 static const char *
@@ -1350,9 +1519,16 @@ hypredrv_MGRclsGetValidValues(const char *key)
 {
    if (!strcmp(key, "type"))
    {
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      static StrIntMap map[] = {
+         {"def", -1},      {"amg", 0}, {"spdirect", 29}, {"ilu", 32},
+         {"fsai", 33},     {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
+      };
+#else
       static StrIntMap map[] = {
          {"def", -1}, {"amg", 0}, {"spdirect", 29}, {"ilu", 32}, {"fsai", 33},
       };
+#endif
 
       return STR_INT_MAP_ARRAY_CREATE(map);
    }
@@ -1371,6 +1547,18 @@ hypredrv_MGRfrlxGetValidValues(const char *key)
 {
    if (!strcmp(key, "type"))
    {
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      static StrIntMap map[] = {
+         {"", -1},          {"none", -1},
+         {"single", 7},     {"jacobi", 7},
+         {"l1-jacobi", 18}, {"v(1,0)", 1},
+         {"amg", 2},        {"mgr", MGR_FRLX_TYPE_NESTED_MGR},
+         {"chebyshev", 16}, {"ilu", 32},
+         {"ge", 9},         {"spdirect", 29},
+         {"ge-piv", 99},    {"ge-inv", 199},
+         {"fsai", 33},      {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
+      };
+#else
       static StrIntMap map[] = {
          {"", -1},          {"none", -1},
          {"single", 7},     {"jacobi", 7},
@@ -1381,6 +1569,7 @@ hypredrv_MGRfrlxGetValidValues(const char *key)
          {"ge-piv", 99},    {"ge-inv", 199},
          {"fsai", 33},
       };
+#endif
 
       return STR_INT_MAP_ARRAY_CREATE(map);
    }
@@ -1399,6 +1588,16 @@ hypredrv_MGRgrlxGetValidValues(const char *key)
 {
    if (!strcmp(key, "type"))
    {
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      static StrIntMap map[] = {
+         {"", -1},         {"none", -1},    {"blk-jacobi", 0}, {"blk-gs", 1},
+         {"mixed-gs", 2},  {"amg", 20},     {"h-fgs", 3},      {"h-bgs", 4},
+         {"ch-gs", 5},     {"h-ssor", 6},   {"euclid", 8},     {"2stg-fgs", 11},
+         {"2stg-bgs", 12}, {"l1-hfgs", 13}, {"l1-hbgs", 14},   {"ilu", 16},
+         {"spdirect", 29}, {"l1-hsgs", 88}, {"fsai", 33},
+         {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
+      };
+#else
       static StrIntMap map[] = {
          {"", -1},         {"none", -1},    {"blk-jacobi", 0}, {"blk-gs", 1},
          {"mixed-gs", 2},  {"amg", 20},     {"h-fgs", 3},      {"h-bgs", 4},
@@ -1406,6 +1605,7 @@ hypredrv_MGRgrlxGetValidValues(const char *key)
          {"2stg-bgs", 12}, {"l1-hfgs", 13}, {"l1-hbgs", 14},   {"ilu", 16},
          {"spdirect", 29}, {"l1-hsgs", 88}, {"fsai", 33},
       };
+#endif
 
       return STR_INT_MAP_ARRAY_CREATE(map);
    }
@@ -1737,6 +1937,12 @@ MGRCoarseSolverTypeName(const MGRcls_args *args)
          return "spdirect";
       case 32:
          return "ilu";
+      case 33:
+         return "fsai";
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      case MGR_SOLVER_TYPE_SCHWARZ:
+         return "schwarz";
+#endif
       default:
          return "unknown";
    }
@@ -1755,7 +1961,11 @@ MGRFRelaxUsesManagedHandle(const MGRfrlx_args *args)
       return 1;
    }
 
-   return args->type == 2 || args->type == 29 || args->type == 32 || args->type == 33;
+   return args->type == 2 || args->type == 29 || args->type == 32 || args->type == 33
+#if HYPREDRV_HAVE_EXPERIMENTAL
+          || args->type == MGR_SOLVER_TYPE_SCHWARZ
+#endif
+      ;
 }
 
 static int
@@ -1782,7 +1992,11 @@ MGRGRelaxUsesManagedHandle(const MGRgrlx_args *args)
       return 1;
    }
 
-   return args->type == 20 || args->type == 16 || args->type == 29 || args->type == 33;
+   return args->type == 20 || args->type == 16 || args->type == 29 || args->type == 33
+#if HYPREDRV_HAVE_EXPERIMENTAL
+          || args->type == MGR_SOLVER_TYPE_SCHWARZ
+#endif
+      ;
 }
 
 static int
@@ -1810,7 +2024,11 @@ MGRCoarseUsesManagedHandle(const MGRcls_args *args)
    }
 
    HYPRE_Int type = MGRResolveCoarseSolverType(args);
-   return type == 0 || type == 29 || type == 32;
+   return type == 0 || type == 29 || type == 32
+#if HYPREDRV_HAVE_EXPERIMENTAL
+          || type == MGR_SOLVER_TYPE_SCHWARZ
+#endif
+      ;
 }
 
 static int
@@ -1942,6 +2160,12 @@ MGRDestroyDetachedFSolver(const MGRfrlx_args *f_relaxation, HYPRE_Solver *solver
       HYPRE_FSAIDestroy(*solver_ptr);
    }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (f_relaxation->type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      MGRSchwarzWrapperDestroy(*solver_ptr);
+   }
+#endif
 
    *solver_ptr = NULL;
 }
@@ -1976,6 +2200,12 @@ MGRDestroyDetachedGSolver(const MGRgrlx_args *g_relaxation, HYPRE_Solver *solver
    else if (g_relaxation->type == 33)
    {
       HYPRE_FSAIDestroy(*solver_ptr);
+   }
+#endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (g_relaxation->type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      MGRSchwarzWrapperDestroy(*solver_ptr);
    }
 #endif
 
@@ -2049,6 +2279,19 @@ MGRRefreshFRelaxAtLevel(MGR_args *args, HYPRE_Solver mgr_solver, int active_lvl,
       hypredrv_FSAICreate(&level_args->f_relaxation.fsai, &fsolver);
    }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (level_args->f_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      if (active_lvl != 0)
+      {
+         hypredrv_ErrorCodeSet(ERROR_INVALID_PRECON);
+         hypredrv_ErrorMsgAdd(
+            "MGR F-relaxation 'schwarz' is only supported at MGR level 0");
+         return;
+      }
+      fsolver = MGRSchwarzWrapperCreate(&level_args->f_relaxation.schwarz);
+   }
+#endif
 
    if (hypredrv_ErrorCodeActive() || !fsolver)
    {
@@ -2056,8 +2299,20 @@ MGRRefreshFRelaxAtLevel(MGR_args *args, HYPRE_Solver mgr_solver, int active_lvl,
    }
 
 #if HYPRE_CHECK_MIN_VERSION(23100, 9)
-   hypredrv_MGRSetFSolverAtLevel(mgr_solver, fsolver, active_lvl,
-                                 level_args->f_relaxation.type, NULL, NULL);
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   if (level_args->f_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      hypredrv_MGRSetFSolverAtLevel(mgr_solver, fsolver, active_lvl,
+                                    MGR_FRLX_TYPE_CUSTOM_SOLVER_CB,
+                                    MGRSchwarzWrapperParSolve,
+                                    MGRSchwarzWrapperParSetup);
+   }
+   else
+#endif
+   {
+      hypredrv_MGRSetFSolverAtLevel(mgr_solver, fsolver, active_lvl,
+                                    level_args->f_relaxation.type, NULL, NULL);
+   }
 #endif
    MGRDestroyDetachedFSolver(&level_args->f_relaxation, &old_fsolver);
    args->frelax[orig_lvl] = fsolver;
@@ -2115,6 +2370,12 @@ MGRRefreshGRelaxAtLevel(MGR_args *args, HYPRE_Solver mgr_solver, int active_lvl,
    else if (level_args->g_relaxation.type == 33)
    {
       hypredrv_FSAICreate(&level_args->g_relaxation.fsai, &smoother);
+   }
+#endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (level_args->g_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      smoother = MGRSchwarzWrapperCreate(&level_args->g_relaxation.schwarz);
    }
 #endif
 
@@ -2190,6 +2451,18 @@ MGRRefreshCoarseSolver(MGR_args *args, HYPRE_Solver mgr_solver)
       args->csolver_type = 29;
    }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   else if (type == MGR_SOLVER_TYPE_SCHWARZ)
+   {
+      hypredrv_SchwarzCreate(&args->coarsest_level.schwarz, &coarse_solver);
+      if (!hypredrv_ErrorCodeActive())
+      {
+         HYPRE_MGRSetCoarseSolver(mgr_solver, HYPRE_SchwarzSolve, HYPRE_SchwarzSetup,
+                                  coarse_solver);
+         args->csolver_type = MGR_SOLVER_TYPE_SCHWARZ;
+      }
+   }
+#endif
 
    if (hypredrv_ErrorCodeActive() || !coarse_solver)
    {
@@ -2212,6 +2485,12 @@ MGRRefreshCoarseSolver(MGR_args *args, HYPRE_Solver mgr_solver)
       else if (old_type == 32)
       {
          HYPRE_ILUDestroy(old_coarse_solver);
+      }
+#endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (old_type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         HYPRE_SchwarzDestroy(old_coarse_solver);
       }
 #endif
    }
@@ -2793,6 +3072,12 @@ hypredrv_MGRDestroyCachedSolvers(MGR_args *args, int hypre_destroyed)
          HYPRE_ILUDestroy(args->csolver);
       }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (args->csolver_type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         HYPRE_SchwarzDestroy(args->csolver);
+      }
+#endif
    }
    if (drop_csolver)
    {
@@ -3247,18 +3532,30 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
 
       if (level_args->f_relaxation.use_krylov)
       {
-         level_frelax_type[i] = 2;
+         level_frelax_type[i] = MGR_FRLX_TYPE_CUSTOM_SOLVER_CB;
       }
       else if (type == MGR_FRLX_TYPE_NESTED_MGR)
       {
          level_frelax_type[i] = 7;
       }
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         level_frelax_type[i] = MGR_FRLX_TYPE_CUSTOM_SOLVER_CB;
+      }
+#endif
       else
       {
          level_frelax_type[i] = type;
       }
       level_frelax_sweeps[i] = level_args->f_relaxation.num_sweeps;
       level_grelax_type[i]   = level_args->g_relaxation.type;
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      if (level_args->g_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         level_grelax_type[i] = MGR_GRLX_TYPE_USER_SMOOTHER;
+      }
+#endif
       level_grelax_sweeps[i] = level_args->g_relaxation.num_sweeps;
       level_interp_type[i]   = MGRLevelInterpTypeCompat(level_args->prolongation_type,
                                                         stats, next_ls_id, orig_lvl);
@@ -3508,6 +3805,44 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
          return;
       }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (level_args->f_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+#if HYPRE_CHECK_MIN_VERSION(23100, 9)
+         if (i != 0)
+         {
+            hypredrv_ErrorCodeSet(ERROR_INVALID_PRECON);
+            hypredrv_ErrorMsgAdd(
+               "MGR F-relaxation 'schwarz' is only supported at MGR level 0");
+            return;
+         }
+         frelax = args->frelax[orig_lvl];
+         if (!frelax)
+         {
+            frelax = MGRSchwarzWrapperCreate(&level_args->f_relaxation.schwarz);
+            if (!frelax || hypredrv_ErrorCodeActive())
+            {
+               return;
+            }
+         }
+         else
+         {
+            HYPREDRV_LOG_COMMF(2, MPI_COMM_WORLD, MGRLogObjectName(stats), next_ls_id,
+                               "reusing cached MGR F-relax solver handle at level %d",
+                               (int)orig_lvl);
+         }
+         hypredrv_MGRSetFSolverAtLevel(precon, frelax, i,
+                                       MGR_FRLX_TYPE_CUSTOM_SOLVER_CB,
+                                       MGRSchwarzWrapperParSolve,
+                                       MGRSchwarzWrapperParSetup);
+         args->frelax[orig_lvl] = frelax;
+#else
+         hypredrv_ErrorCodeSet(ERROR_INVALID_PRECON);
+         hypredrv_ErrorMsgAdd("MGR F-relaxation 'schwarz' requires hypre >= 2.31.0");
+         return;
+#endif
+      }
+#endif
    }
    HYPREDRV_LOG_COMMF(4, MPI_COMM_WORLD, MGRLogObjectName(stats), next_ls_id,
                       "MGR stage after F-relax setup: code=0x%x",
@@ -3643,6 +3978,28 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
          return;
       }
 #endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (level_args->g_relaxation.type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         grelax = args->grelax[orig_lvl];
+         if (!grelax)
+         {
+            grelax = MGRSchwarzWrapperCreate(&level_args->g_relaxation.schwarz);
+            if (!grelax || hypredrv_ErrorCodeActive())
+            {
+               return;
+            }
+         }
+         else
+         {
+            HYPREDRV_LOG_COMMF(2, MPI_COMM_WORLD, MGRLogObjectName(stats), next_ls_id,
+                               "reusing cached MGR G-relax solver handle at level %d",
+                               (int)orig_lvl);
+         }
+         HYPRE_MGRSetGlobalSmootherAtLevel(precon, grelax, i);
+         args->grelax[orig_lvl] = grelax;
+      }
+#endif
    }
 #endif
    HYPREDRV_LOG_COMMF(4, MPI_COMM_WORLD, MGRLogObjectName(stats), next_ls_id,
@@ -3705,6 +4062,13 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
       {
          args->coarsest_level.ilu.max_iter = 1;
       }
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (args->coarsest_level.type == MGR_SOLVER_TYPE_SCHWARZ &&
+               args->coarsest_level.schwarz.max_iter < 1)
+      {
+         args->coarsest_level.schwarz.max_iter = 1;
+      }
+#endif
       /* GCOVR_EXCL_STOP */
 
       /* Config coarsest level solver */
@@ -3804,6 +4168,29 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
          hypredrv_ErrorCodeSet(ERROR_INVALID_PRECON);
          hypredrv_ErrorMsgAdd("MGR coarsest_level 'fsai' requires hypre >= 2.25.0");
          return;
+      }
+#endif
+#if HYPREDRV_HAVE_EXPERIMENTAL
+      else if (args->coarsest_level.type == MGR_SOLVER_TYPE_SCHWARZ)
+      {
+         int csolver_was_cached =
+            (args->csolver && args->csolver_type == MGR_SOLVER_TYPE_SCHWARZ);
+         if (!csolver_was_cached)
+         {
+            hypredrv_SchwarzCreate(&args->coarsest_level.schwarz, &args->csolver);
+            if (!args->csolver || hypredrv_ErrorCodeActive())
+            {
+               return;
+            }
+         }
+         else
+         {
+            HYPREDRV_LOG_COMMF(2, MPI_COMM_WORLD, MGRLogObjectName(stats), next_ls_id,
+                               "reusing cached MGR coarsest solver handle");
+         }
+         args->csolver_type = MGR_SOLVER_TYPE_SCHWARZ;
+         HYPRE_MGRSetCoarseSolver(precon, HYPRE_SchwarzSolve, HYPRE_SchwarzSetup,
+                                  args->csolver);
       }
 #endif
    }

--- a/src/mgr.c
+++ b/src/mgr.c
@@ -46,14 +46,13 @@ typedef struct MGRSchwarzWrapper_struct
 
 enum
 {
-   MGR_HYPRE_SOLVER_IS_SETUP_OFFSET =
-      sizeof(HYPRE_PtrToSolverFcn) + sizeof(HYPRE_PtrToSolverFcn) +
-      sizeof(HYPRE_PtrToDestroyFcn),
+   MGR_HYPRE_SOLVER_IS_SETUP_OFFSET = sizeof(HYPRE_PtrToSolverFcn) +
+                                      sizeof(HYPRE_PtrToSolverFcn) +
+                                      sizeof(HYPRE_PtrToDestroyFcn),
 };
 
 typedef char MGRSchwarzWrapperLayoutCheck
-   [(offsetof(MGRSchwarzWrapper, is_setup) == MGR_HYPRE_SOLVER_IS_SETUP_OFFSET) ? 1 :
-                                                                                  -1];
+   [(offsetof(MGRSchwarzWrapper, is_setup) == MGR_HYPRE_SOLVER_IS_SETUP_OFFSET) ? 1 : -1];
 #endif
 
 static MGRFRelaxWrapper *g_mgr_frelax_wrapper_live_head = NULL;
@@ -281,8 +280,7 @@ MGRSchwarzWrapperSolve(HYPRE_Solver wrapper_v, HYPRE_Matrix A, HYPRE_Vector b,
       return 1;
    }
 
-   if (!wrapper->is_setup &&
-       MGRSchwarzWrapperSetup(wrapper_v, A, b, x))
+   if (!wrapper->is_setup && MGRSchwarzWrapperSetup(wrapper_v, A, b, x))
    {
       return 1;
    }
@@ -310,16 +308,16 @@ MGRSchwarzWrapperDestroy(HYPRE_Solver wrapper_v)
 }
 
 static HYPRE_Int
-MGRSchwarzWrapperParSetup(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A,
-                          HYPRE_ParVector b, HYPRE_ParVector x)
+MGRSchwarzWrapperParSetup(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A, HYPRE_ParVector b,
+                          HYPRE_ParVector x)
 {
    return MGRSchwarzWrapperSetup(wrapper, (HYPRE_Matrix)A, (HYPRE_Vector)b,
                                  (HYPRE_Vector)x);
 }
 
 static HYPRE_Int
-MGRSchwarzWrapperParSolve(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A,
-                          HYPRE_ParVector b, HYPRE_ParVector x)
+MGRSchwarzWrapperParSolve(HYPRE_Solver wrapper, HYPRE_ParCSRMatrix A, HYPRE_ParVector b,
+                          HYPRE_ParVector x)
 {
    return MGRSchwarzWrapperSolve(wrapper, (HYPRE_Matrix)A, (HYPRE_Vector)b,
                                  (HYPRE_Vector)x);
@@ -482,10 +480,10 @@ DEFINE_TYPED_SETTER(MGRgrlxFSAISetArgs, MGRgrlx_args, fsai, 33, hypredrv_FSAISet
 #if HYPREDRV_HAVE_EXPERIMENTAL
 DEFINE_TYPED_SETTER(MGRclsSchwarzSetArgs, MGRcls_args, schwarz, MGR_SOLVER_TYPE_SCHWARZ,
                     hypredrv_SchwarzSetArgs)
-DEFINE_TYPED_SETTER(MGRfrlxSchwarzSetArgs, MGRfrlx_args, schwarz,
-                    MGR_SOLVER_TYPE_SCHWARZ, hypredrv_SchwarzSetArgs)
-DEFINE_TYPED_SETTER(MGRgrlxSchwarzSetArgs, MGRgrlx_args, schwarz,
-                    MGR_SOLVER_TYPE_SCHWARZ, hypredrv_SchwarzSetArgs)
+DEFINE_TYPED_SETTER(MGRfrlxSchwarzSetArgs, MGRfrlx_args, schwarz, MGR_SOLVER_TYPE_SCHWARZ,
+                    hypredrv_SchwarzSetArgs)
+DEFINE_TYPED_SETTER(MGRgrlxSchwarzSetArgs, MGRgrlx_args, schwarz, MGR_SOLVER_TYPE_SCHWARZ,
+                    hypredrv_SchwarzSetArgs)
 #endif
 static void MGRfrlxMGRSetArgs(void *, const YAMLnode *);
 void        hypredrv_MGRSetArgsFromYAML(void *, YAMLnode *);
@@ -503,28 +501,28 @@ void        hypredrv_MGRSetArgsFromYAML(void *, YAMLnode *);
 #define MGRgrlx_SCHWARZ_FIELD(_prefix)
 #endif
 
-#define MGRcls_FIELDS(_prefix)                                      \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)  \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRclsAMGSetArgs)           \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRclsILUSetArgs)           \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRclsFSAISetArgs)         \
+#define MGRcls_FIELDS(_prefix)                                     \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRclsAMGSetArgs)          \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRclsILUSetArgs)          \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRclsFSAISetArgs)        \
    MGRcls_SCHWARZ_FIELD(_prefix)
 
-#define MGRfrlx_FIELDS(_prefix)                                           \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)        \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet)  \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, mgr, MGRfrlxMGRSetArgs)                \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRfrlxAMGSetArgs)                \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRfrlxILUSetArgs)                \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRfrlxFSAISetArgs)              \
+#define MGRfrlx_FIELDS(_prefix)                                          \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)       \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, mgr, MGRfrlxMGRSetArgs)               \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRfrlxAMGSetArgs)               \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRfrlxILUSetArgs)               \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRfrlxFSAISetArgs)             \
    MGRfrlx_SCHWARZ_FIELD(_prefix)
 
-#define MGRgrlx_FIELDS(_prefix)                                           \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)        \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet)  \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRgrlxAMGSetArgs)                \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRgrlxILUSetArgs)                \
-   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRgrlxFSAISetArgs)              \
+#define MGRgrlx_FIELDS(_prefix)                                          \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, type, hypredrv_FieldTypeIntSet)       \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, num_sweeps, hypredrv_FieldTypeIntSet) \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, amg, MGRgrlxAMGSetArgs)               \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, ilu, MGRgrlxILUSetArgs)               \
+   ADD_FIELD_OFFSET_ENTRY(_prefix, fsai, MGRgrlxFSAISetArgs)             \
    MGRgrlx_SCHWARZ_FIELD(_prefix)
 
 #define MGRlvl_FIELDS(_prefix)                                                  \
@@ -1521,8 +1519,8 @@ hypredrv_MGRclsGetValidValues(const char *key)
    {
 #if HYPREDRV_HAVE_EXPERIMENTAL
       static StrIntMap map[] = {
-         {"def", -1},      {"amg", 0}, {"spdirect", 29}, {"ilu", 32},
-         {"fsai", 33},     {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
+         {"def", -1}, {"amg", 0},   {"spdirect", 29},
+         {"ilu", 32}, {"fsai", 33}, {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
       };
 #else
       static StrIntMap map[] = {
@@ -1590,12 +1588,16 @@ hypredrv_MGRgrlxGetValidValues(const char *key)
    {
 #if HYPREDRV_HAVE_EXPERIMENTAL
       static StrIntMap map[] = {
-         {"", -1},         {"none", -1},    {"blk-jacobi", 0}, {"blk-gs", 1},
-         {"mixed-gs", 2},  {"amg", 20},     {"h-fgs", 3},      {"h-bgs", 4},
-         {"ch-gs", 5},     {"h-ssor", 6},   {"euclid", 8},     {"2stg-fgs", 11},
-         {"2stg-bgs", 12}, {"l1-hfgs", 13}, {"l1-hbgs", 14},   {"ilu", 16},
-         {"spdirect", 29}, {"l1-hsgs", 88}, {"fsai", 33},
-         {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
+         {"", -1},          {"none", -1},
+         {"blk-jacobi", 0}, {"blk-gs", 1},
+         {"mixed-gs", 2},   {"amg", 20},
+         {"h-fgs", 3},      {"h-bgs", 4},
+         {"ch-gs", 5},      {"h-ssor", 6},
+         {"euclid", 8},     {"2stg-fgs", 11},
+         {"2stg-bgs", 12},  {"l1-hfgs", 13},
+         {"l1-hbgs", 14},   {"ilu", 16},
+         {"spdirect", 29},  {"l1-hsgs", 88},
+         {"fsai", 33},      {"schwarz", MGR_SOLVER_TYPE_SCHWARZ},
       };
 #else
       static StrIntMap map[] = {
@@ -2304,8 +2306,7 @@ MGRRefreshFRelaxAtLevel(MGR_args *args, HYPRE_Solver mgr_solver, int active_lvl,
    {
       hypredrv_MGRSetFSolverAtLevel(mgr_solver, fsolver, active_lvl,
                                     MGR_FRLX_TYPE_CUSTOM_SOLVER_CB,
-                                    MGRSchwarzWrapperParSolve,
-                                    MGRSchwarzWrapperParSetup);
+                                    MGRSchwarzWrapperParSolve, MGRSchwarzWrapperParSetup);
    }
    else
 #endif
@@ -3831,8 +3832,7 @@ hypredrv_MGRCreate(MGR_args *args, HYPRE_Solver *precon_ptr, const Stats *stats,
                                "reusing cached MGR F-relax solver handle at level %d",
                                (int)orig_lvl);
          }
-         hypredrv_MGRSetFSolverAtLevel(precon, frelax, i,
-                                       MGR_FRLX_TYPE_CUSTOM_SOLVER_CB,
+         hypredrv_MGRSetFSolverAtLevel(precon, frelax, i, MGR_FRLX_TYPE_CUSTOM_SOLVER_CB,
                                        MGRSchwarzWrapperParSolve,
                                        MGRSchwarzWrapperParSetup);
          args->frelax[orig_lvl] = frelax;

--- a/tests/test_args.c
+++ b/tests/test_args.c
@@ -1560,6 +1560,48 @@ test_InputArgsParse_include_from_subdirectory(void)
 }
 
 static void
+test_InputArgsParse_parent_relative_config_path(void)
+{
+   char cwd[512];
+   char dir[256];
+   char subdir[288];
+   char config[288];
+   input_args *args = NULL;
+
+   ASSERT_NOT_NULL(getcwd(cwd, sizeof(cwd)));
+
+   (void)snprintf(dir, sizeof(dir), "/tmp/hypred_args_parent_%d", (int)getpid());
+   (void)snprintf(subdir, sizeof(subdir), "%s/run", dir);
+   (void)snprintf(config, sizeof(config), "%s/config.yml", dir);
+
+   ASSERT_EQ(mkdir(dir, 0700), 0);
+   ASSERT_EQ(mkdir(subdir, 0700), 0);
+
+   FILE *fp = fopen(config, "w");
+   ASSERT_NOT_NULL(fp);
+   fprintf(fp, "solver: pcg\n");
+   fprintf(fp, "preconditioner: amg\n");
+   fclose(fp);
+
+   ASSERT_EQ(chdir(subdir), 0);
+   char *argv[] = {"../config.yml"};
+
+   hypredrv_ErrorCodeResetAll();
+   hypredrv_InputArgsParse(MPI_COMM_SELF, false, 1, argv, &args);
+
+   ASSERT_EQ(chdir(cwd), 0);
+
+   ASSERT_NOT_NULL(args);
+   ASSERT_EQ(args->solver_method, SOLVER_PCG);
+   ASSERT_EQ(args->precon_method, PRECON_BOOMERAMG);
+
+   hypredrv_InputArgsDestroy(&args);
+   unlink(config);
+   rmdir(subdir);
+   rmdir(dir);
+}
+
+static void
 test_InputArgsParse_driver_mode_config_not_argv0_with_overrides(void)
 {
    char yaml_file[256];
@@ -1937,6 +1979,7 @@ main(int argc, char **argv)
    RUN_TEST(test_hypredrv_InputArgsApplySolverPreset_unknown_preset);
    RUN_TEST(test_InputArgsParse_invalid_yaml_file_on_disk);
    RUN_TEST(test_InputArgsParse_include_from_subdirectory);
+   RUN_TEST(test_InputArgsParse_parent_relative_config_path);
    RUN_TEST(test_InputArgsParse_driver_mode_config_not_argv0_with_overrides);
    RUN_TEST(test_InputArgsParseWithObjectName_basic);
    RUN_TEST(test_InputArgsParseWithObjectName_invalid_yaml_tree);

--- a/tests/test_args.c
+++ b/tests/test_args.c
@@ -1589,7 +1589,10 @@ test_InputArgsParse_parent_relative_config_path(void)
    hypredrv_ErrorCodeResetAll();
    hypredrv_InputArgsParse(MPI_COMM_SELF, false, 1, argv, &args);
 
-   ASSERT_EQ(chdir(cwd), 0);
+   /* Restore cwd before any result assertions so later tests are unaffected
+    * if the parse unexpectedly fails. */
+   int restore_cwd = chdir(cwd);
+   ASSERT_EQ(restore_cwd, 0);
 
    ASSERT_NOT_NULL(args);
    ASSERT_EQ(args->solver_method, SOLVER_PCG);

--- a/tests/test_error.c
+++ b/tests/test_error.c
@@ -109,6 +109,23 @@ test_ErrorStateReset(void)
 }
 
 static void
+test_ErrorReportCollectiveFlag_resets(void)
+{
+   hypredrv_ErrorCodeResetAll();
+   ASSERT_FALSE(hypredrv_ErrorReportIsCollective());
+
+   hypredrv_ErrorReportSetCollective(true);
+   ASSERT_TRUE(hypredrv_ErrorReportIsCollective());
+
+   hypredrv_ErrorCodeResetAll();
+   ASSERT_FALSE(hypredrv_ErrorReportIsCollective());
+
+   hypredrv_ErrorReportSetCollective(true);
+   hypredrv_ErrorStateReset();
+   ASSERT_FALSE(hypredrv_ErrorReportIsCollective());
+}
+
+static void
 test_ErrorMsgAdd_null_format(void)
 {
    hypredrv_ErrorMsgClear();
@@ -563,6 +580,7 @@ main(int argc, char **argv)
    RUN_TEST(test_ErrorMsgAdd);
    RUN_TEST(test_ErrorMsgClear);
    RUN_TEST(test_ErrorStateReset);
+   RUN_TEST(test_ErrorReportCollectiveFlag_resets);
    RUN_TEST(test_ErrorMsgAdd_null_format);
    RUN_TEST(test_ErrorMsgHelpers_accept_null_inputs);
    RUN_TEST(test_ErrorMsgAddMissingKey);

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -718,6 +718,49 @@ test_mgr_f_relaxation_ilu_nested_block(void)
    hypredrv_MGRDestroyNestedSolverArgs(&args);
 }
 
+#if HYPREDRV_HAVE_EXPERIMENTAL
+static void
+test_mgr_schwarz_nested_blocks_for_f_g_and_coarsest(void)
+{
+   MGR_args args;
+   hypredrv_MGRSetDefaultArgs(&args);
+
+   YAMLnode *mgr = hypredrv_YAMLnodeCreate("mgr", "", 0);
+   YAMLnode *levels = add_child(mgr, "level", "", 1);
+   YAMLnode *lvl0 = add_child(levels, "0", "", 2);
+   add_child(lvl0, "f_dofs", "[0]", 3);
+
+   YAMLnode *f0 = add_child(lvl0, "f_relaxation", "", 3);
+   YAMLnode *f0_schwarz = add_child(f0, "schwarz", "", 4);
+   add_child(f0_schwarz, "variant", "ras-iluk", 5);
+   add_child(f0_schwarz, "overlap", "2", 5);
+
+   YAMLnode *g0 = add_child(lvl0, "g_relaxation", "", 3);
+   YAMLnode *g0_schwarz = add_child(g0, "schwarz", "", 4);
+   add_child(g0_schwarz, "variant", "ras-ilut", 5);
+   add_child(g0_schwarz, "local_solver_type", "ilut", 5);
+
+   YAMLnode *cls = add_child(mgr, "coarsest_level", "", 1);
+   YAMLnode *cls_schwarz = add_child(cls, "schwarz", "", 2);
+   add_child(cls_schwarz, "variant", "ras-spdirect", 3);
+
+   hypredrv_ErrorCodeResetAll();
+   hypredrv_MGRSetArgsFromYAML(&args, mgr);
+   ASSERT_FALSE(hypredrv_ErrorCodeActive());
+   ASSERT_EQ((int)args.level[0].f_relaxation.type, MGR_SOLVER_TYPE_SCHWARZ);
+   ASSERT_EQ((int)args.level[0].f_relaxation.schwarz.variant, 10);
+   ASSERT_EQ((int)args.level[0].f_relaxation.schwarz.overlap, 2);
+   ASSERT_EQ((int)args.level[0].g_relaxation.type, MGR_SOLVER_TYPE_SCHWARZ);
+   ASSERT_EQ((int)args.level[0].g_relaxation.schwarz.variant, 20);
+   ASSERT_EQ((int)args.level[0].g_relaxation.schwarz.local_solver_type, 1);
+   ASSERT_EQ((int)args.coarsest_level.type, MGR_SOLVER_TYPE_SCHWARZ);
+   ASSERT_EQ((int)args.coarsest_level.schwarz.variant, 40);
+
+   hypredrv_YAMLnodeDestroy(mgr);
+   hypredrv_MGRDestroyNestedSolverArgs(&args);
+}
+#endif
+
 /* Flat-value branches (no children) in cls/frlx/grlx SetArgsFromYAML */
 static void
 test_mgr_cls_frxl_grlx_flat_scalar_branches(void)
@@ -1086,6 +1129,9 @@ main(int argc, char **argv)
    RUN_TEST(test_mgr_f_dofs_block_sequence_symbolic_error_returns_early);
    RUN_TEST(test_mgr_explicit_type_key_triggers_apply_type_defaults);
    RUN_TEST(test_mgr_f_relaxation_ilu_nested_block);
+#if HYPREDRV_HAVE_EXPERIMENTAL
+   RUN_TEST(test_mgr_schwarz_nested_blocks_for_f_g_and_coarsest);
+#endif
    RUN_TEST(test_mgr_cls_frxl_grlx_flat_scalar_branches);
    RUN_TEST(test_mgr_MGR_setters_null_parent_early_return);
    RUN_TEST(test_mgr_MGRDestroyNestedSolverArgs_null);


### PR DESCRIPTION
  This PR adds experimental Schwarz support in MGR and cleans up error reporting/config path handling and extends .

  - Moves safe-call error handling into src/error.c, so global/collective errors can report once on rank 0 while still aborting all ranks.
  - Fixes relative config path handling by relying on the realpath-based validation path instead of rejecting valid parent-relative inputs.
  - Adds tests for global error reporting and parent-relative config paths.
  - Enables experimental Schwarz as an MGR F-relaxation, G-relaxation, and coarsest-level solver.
  - Adds an internal Schwarz wrapper for MGR F/G user-solver paths, with named constants documenting the hypre callback/smoother sentinel values.
  - Adds lidcavity Schwarz YAMLs and tests for top-level Schwarz, MGR F-relaxation, G-relaxation, and coarsest-level use.

